### PR TITLE
Add URL analyst mode surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:8000 npm run dev
 # opens http://localhost:3000
 
 # Tests
-pytest -q                              # backend (226 tests)
+pytest -q                              # backend (230 tests)
 ruff check src tests                   # lint
 mypy src                               # type check
 cd ui && npm run lint && npm run build  # frontend
@@ -36,7 +36,7 @@ cd ui && npm run lint && npm run build  # frontend
 | `POST /api/v1/url/check` | Analyze a URL for homoglyph/IDN tricks, ASCII lookalikes, suspicious structure, IP literals, and optional redirect-chain following |
 | `POST /api/v1/email/check` | Analyze raw email authentication headers (SPF/DKIM/DMARC) |
 | `POST /api/v1/qr/scan` | Upload a QR image, decode payloads, extract URLs, run URL analysis |
-| `POST /api/v2/analyze` | Unified endpoint for URL, email_headers, and email_file input types with family-friendly summaries |
+| `POST /api/v2/analyze` | Unified endpoint for URL, email_headers, and email_file input types with family summaries plus URL analyst projections |
 
 **CLI** (`lsh`): `check`, `email-check`, `qr-scan` commands with `--json`, `--family`, `--network`, and allowlist flags.
 
@@ -48,11 +48,11 @@ cd ui && npm run lint && npm run build  # frontend
 | `/url` | Standalone URL check |
 | `/email` | Standalone email header check |
 | `/qr` | Standalone QR scan |
-| `/analyze` | Unified workspace with URL/Email/QR tabs, Quick mode (verdict-first UX) and Analyst mode (raw contract details) |
+| `/analyze` | Unified workspace with URL/Email/QR tabs, Quick mode (verdict-first UX) and URL Analyst mode (domain anatomy, redirect path, suppression trace, evidence panel) |
 
 **Detection modules**: `homoglyph` (Unicode/IDN), `ascii_lookalike` (leet/brand), `url_structure` (deceptive patterns), `net_ip` (IP literals), `redirect` (opt-in redirect chains), `email_auth` (SPF/DKIM/DMARC), `qr_decode` (QR payload extraction).
 
-## Current Status (2026-03-07)
+## Current Status (2026-03-08)
 
 Implemented now:
 
@@ -66,7 +66,7 @@ Implemented now:
 - Minimal FastAPI adapter in `src/lsh/adapters/api.py` (optional dependency; QR upload route degrades gracefully when `python-multipart` is missing)
 - Reusable family formatter layer in `src/lsh/formatters/family.py`
 - Reusable structured response wrappers in `src/lsh/formatters/structured.py`
-- Draft unified v2 endpoint (`POST /api/v2/analyze`) plus v1/v2 parity and edge-case test coverage
+- Draft unified v2 endpoint (`POST /api/v2/analyze`) plus v1/v2 parity, analyst projections, and edge-case test coverage
 - URL-focused offline modules:
   - `homoglyph` (Unicode/IDN spoofing)
   - `ascii_lookalike` (ASCII glyph and leet brand lookalikes)
@@ -85,6 +85,9 @@ Implemented now:
 - JSON output for machine-readable integrations (`--json`)
 - Adversarial regression coverage (obfuscated IPs, fragment deception, encoding evasion)
 - Aggregate scoring policy clarified: overall risk is `risk_score`-based; `confidence` is for trust-calibration messaging
+- Unified `/analyze` workspace with extracted Quick/Analyst result panels in `ui/app/analyze/`
+- URL-first analyst payloads on `/api/v2/analyze` with domain anatomy, redirect path, suppression trace, and evidence rows
+- Compare-ready analyst evidence/suppression keys (`finding_key`, `compare_key`, keyed evidence maps) for future history/delta views
 - V2 execution artifacts and tracking:
   - blueprint: `docs/V2_BLUEPRINT.md`
   - roadmap/issues tracker: `docs/V2_ROADMAP_ISSUES.md`
@@ -93,8 +96,8 @@ Implemented now:
 In progress and next:
 
 - Hosted validation closure for Session 9 deployment checklist
-- Full v2 `/analyze` workspace UX (Quick/Analyst mode split)
-- v2 policy management, history/compare flows, and hardening milestones (tracked in `docs/V2_ROADMAP_ISSUES.md`)
+- Email/QR analyst-mode parity beyond the current URL-first slice
+- v2 policy management, persisted history/compare flows, and hardening milestones (tracked in `docs/V2_ROADMAP_ISSUES.md`)
 
 ## Quick Start
 

--- a/SESSION_LOG.md
+++ b/SESSION_LOG.md
@@ -2310,3 +2310,60 @@ Development session history. Each entry documents what was done, why, and what's
 - `npm run typecheck` passed in `ui/`.
 - `npm run smoke:e2e` passed locally against a live API + built UI (`3 passed`).
 - Local verification used a temporary API instance on `127.0.0.1:8010` and the built UI on `127.0.0.1:3000`.
+
+---
+
+## 2026-03-08 - Session 14A: URL analyst compare-ready contract and docs sync
+
+**Agent:** Codex
+
+**Branch:** `codex/analyst-mode-url-slice`
+
+**Goal:** Finish the URL-first Analyst Mode slice by adding compare-stable analyst evidence keys, then sync the API/roadmap/docs state before closing the branch for review.
+
+**Module(s) Touched:** structured formatter, API response models, UI API types, mocked verdict fixtures, README/API/architecture/roadmap docs, session log
+
+**Changes:**
+- Added compare-ready fields to URL analyst evidence rows in `src/lsh/formatters/structured.py`:
+  - `finding_key`
+  - `compare_key`
+  - `sort_index`
+  - `risk_delta`
+  - keyed `evidence[]`
+  - flattened `evidence_map`
+- Added compare-ready fields to suppression trace rows:
+  - `finding_key`
+  - `compare_key`
+  - `sort_index`
+- Extended typed API contracts in `src/lsh/adapters/api_models.py` and `ui/lib/api.ts` to match the new analyst payload shape.
+- Updated structured/api tests and regenerated the v1/v2 snapshot fixture so the additive v2 URL changes stay governed.
+- Synced docs to the current implementation:
+  - `README.md`
+  - `ui/README.md`
+  - `docs/API_INTEGRATION.md`
+  - `docs/ARCHITECTURE.md`
+  - `docs/ROADMAP.md`
+  - `docs/V2_ROADMAP_ISSUES.md`
+  - `docs/issues/V2_E4_ANALYST_MODE.md`
+- Updated mocked analyst-mode browser fixtures to reflect the richer v2 analyst contract.
+
+**Decisions:**
+- Kept compare metadata additive inside the existing URL analyst payload instead of introducing a second compare-specific API shape. This preserves current UI behavior while giving future history/delta views stable join keys.
+- Used normalized machine keys for evidence labels (`evidence[].key` + `evidence_map`) so future compare logic does not need to diff on presentation-only labels.
+- Left email and QR analyst output on the current fallback path; compare-ready shaping in this session remains intentionally URL-first.
+
+**Open Questions:**
+- When history/compare is implemented, should we persist the full analyst payload per run, or recompute analyst projections from stored `AnalysisResult` + policy metadata at read time?
+
+**Next:**
+- Watch PR #13 after the compare-ready/doc-sync commit lands.
+- If checks are green, merge or hand off for review and close the session.
+- Start E5 policy-pack persistence after this PR is settled.
+
+**Tests / Verification:**
+- `ruff check src tests`
+- `python -m pytest -q`
+- `npm run lint`
+- `npm run build`
+- `gh pr checks 13 --watch`
+

--- a/docs/API_INTEGRATION.md
+++ b/docs/API_INTEGRATION.md
@@ -4,7 +4,7 @@
 
 Current stable contract: `1.0` (`/api/v1/*`)  
 Current draft contract: `2.0` (`/api/v2/analyze`)  
-Updated: `2026-03-05` (E1-I4 parity governance update)
+Updated: `2026-03-08` (E4 analyst-mode compare-ready contract update)
 
 This document is the integration source of truth for backend consumers (Next.js UI, scripts, and service callers).
 
@@ -141,6 +141,7 @@ For `POST /api/v2/analyze`:
 - `schema_version` is `"2.0"`
 - `flow` is `"analyze"`
 - `mode` is currently `"single"`
+- URL responses add `item.analyst`; email responses do not require it
 
 ### Single-mode shape
 
@@ -174,6 +175,61 @@ For `POST /api/v2/analyze`:
   ]
 }
 ```
+
+### URL analyst shape (`/api/v2/analyze`, `input_type="url"`)
+
+`item.analyst` is additive and currently URL-only.
+
+```json
+{
+  "domain_anatomy": { "... normalized URL and host breakdown ..." },
+  "evidence_rows": [
+    {
+      "module": "homoglyph",
+      "category": "HMG004_CONFUSABLE_CHARACTERS",
+      "finding_key": "homoglyph:HMG004_CONFUSABLE_CHARACTERS",
+      "compare_key": "homoglyph:HMG004_CONFUSABLE_CHARACTERS",
+      "sort_index": 0,
+      "risk_delta": 25,
+      "evidence": [
+        { "key": "hostname", "label": "Hostname", "value": "?pple.com" }
+      ],
+      "evidence_map": {
+        "hostname": "?pple.com"
+      }
+    }
+  ],
+  "redirect_trace": { "... optional redirect timeline ..." },
+  "suppression_trace": {
+    "configured_allowlist_domains": ["trusted.example"],
+    "suppressed_rows": [
+      {
+        "finding_key": "homoglyph:HMG002_PUNYCODE_VISIBILITY",
+        "compare_key": "homoglyph:HMG002_PUNYCODE_VISIBILITY:finding:hmg002_punycode_visibility",
+        "sort_index": 0,
+        "suppression_scope": "finding"
+      }
+    ]
+  }
+}
+```
+
+Compare-ready additions:
+
+- `finding_key`: stable semantic key for one finding family (`<module>:<category>`)
+- `compare_key`: deterministic row key for future history/delta matching; may diverge from `finding_key` if duplicate finding families ever appear
+- `sort_index`: deterministic presentation order after analyst sorting
+- `risk_delta`: parsed integer delta when evidence includes `Risk Delta`
+- `evidence[].key`: normalized machine key for one evidence label (`character_mapping`, `redirect_hops`, etc.)
+- `evidence_map`: flattened keyed evidence object for cheap compare/diff logic
+- `suppression_trace.suppressed_rows[*].compare_key`: stable suppression-row key for future policy/history diff views
+
+Current analyst sections:
+
+- `domain_anatomy`: submitted/canonical URL, host labels, IDNA forms, IP-literal markers, normalization notes
+- `evidence_rows`: UI-ready finding rows sorted by highest cumulative risk first
+- `redirect_trace`: optional redirect chain projection built from redirect findings
+- `suppression_trace`: allowlist inputs plus structured suppressed-finding rows
 
 ### QR compatibility keys
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,14 +4,14 @@
 
 Modules detect. Core orchestrates and scores. Application services compose. Adapters render.
 
-## Implemented Architecture (2026-03-05)
+## Implemented Architecture (2026-03-08)
 
 ### Core Layer (`src/lsh/core/`)
 
 - `models.py`: canonical data contracts (`AnalysisInput`, `Finding`, `AnalysisResult`, `NormalizedURL`)
-- `allowlist.py`: normalized domain allowlist helpers with category-prefix scoping
+- `allowlist.py`: normalized domain allowlist helpers with category-prefix scoping plus runtime suppression-trace capture
 - `url_tools.py`: shared URL parsing and registrable-domain extraction (offline heuristics)
-- `context.py`: shared runtime context/preprocessing cache for one analysis run (URL-focused today)
+- `context.py`: shared runtime context/preprocessing cache for one analysis run (URL-focused today), including analyst-only suppression events
 - `normalizer.py`: deterministic URL normalization helpers (percent-decoding, obfuscated IP parsing, localhost aliases, IPv6-mapped IPv4, path normalization)
 - `scorer.py`: severity mapping, finding normalization, and compound aggregate risk calculation (`risk_score`-based; confidence is informational)
 - `orchestrator.py`: module execution + aggregate result construction + confidence-aware summary text
@@ -46,7 +46,7 @@ Modules detect. Core orchestrates and scores. Application services compose. Adap
 ### Formatter Layer (`src/lsh/formatters/`)
 
 - `family.py`: reusable family-facing formatter used by the CLI and ready for future web/API adapters
-- `structured.py`: stable single/multi-item response wrappers shared by CLI JSON and API responses
+- `structured.py`: stable single/multi-item response wrappers shared by CLI JSON and API responses, including v2 URL analyst projections and compare-ready evidence keys
 
 ## Runtime Flow
 
@@ -55,14 +55,15 @@ Modules detect. Core orchestrates and scores. Application services compose. Adap
 3. Application service routes to shared orchestrators (URL or email).
 4. Orchestrator builds runtime context once (for URL inputs), runs modules, then normalizes and aggregates findings.
 5. Orchestrator returns `AnalysisResult` with summary wording influenced by overall risk and confidence.
-6. Adapters render technical/family/structured outputs using shared formatter helpers.
+6. Structured formatters can project analyst-only URL views (domain anatomy, redirects, suppression rows) from runtime context without changing the base `AnalysisResult` model.
+7. Adapters render technical/family/structured outputs using shared formatter helpers.
 
 ## Current URL Processing Reality (Important)
 
 - Orchestrator now builds one shared URL runtime context per analysis, including normalized/canonical URL data.
 - `net_ip`, `url_structure`, `homoglyph`, and `ascii_lookalike` use the shared context.
 - Orchestrator now routes modules by declared `supported_input_types` before execution.
-- The runtime context is internal and attached to `AnalysisInput` as non-serialized runtime state, so JSON output contracts stay stable.
+- The runtime context is internal and attached to `AnalysisInput` as non-serialized runtime state, so base JSON contracts stay stable while v2 analyst projections can still expose selected derived fields.
 
 ## Runtime URL Context (Current Shape)
 
@@ -78,11 +79,13 @@ Contains (URL inputs):
 - raw + canonical hostname and registrable-domain values
 - IDNA ASCII/Unicode hostname forms (best effort)
 - parsed literal-IP / obfuscated-IP / IPv6-mapped-IPv4 helpers
+- structured suppression-trace events recorded when allowlist rules suppress URL findings
 
 Why non-serialized runtime state:
 
 - keeps the public `AnalysisResult` / CLI JSON contract unchanged
 - avoids leaking internal preprocessing details into downstream consumers before the API schema is intentionally designed
+- allows additive v2 analyst projections (including suppression traces) without a breaking model change
 - allows gradual detector migration without a breaking model change
 
 ## Contract Requirements

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -141,6 +141,20 @@ Shift Quick mode from a generic summary layout to a decision-first surface.
 4. [x] Complete plain-language copy pass for all major outcomes across flows.
 5. [x] Add broader UX/usability validation beyond the current smoke path.
 
+## Session 14: URL Analyst Mode Deep Evidence Slice (2026-03-08)
+
+### Goal
+
+Finish the first shippable URL Analyst Mode surface and make the v2 contract ready for future compare/history work.
+
+### Work Items
+
+1. [x] Add URL-only `item.analyst` payloads on `/api/v2/analyze` with domain anatomy and evidence rows.
+2. [x] Add redirect-path projection for network-enabled URL findings.
+3. [x] Add suppression-trace visibility from allowlist decisions through API and UI.
+4. [x] Add compare-ready evidence keys (`finding_key`, `compare_key`, keyed evidence maps) for future delta views.
+5. [x] Sync API/docs/roadmap state with the delivered analyst-mode contract.
+
 ## Risks and Mitigations
 
 - Risk: network-dependent logic increases flaky tests

--- a/docs/V2_ROADMAP_ISSUES.md
+++ b/docs/V2_ROADMAP_ISSUES.md
@@ -1,6 +1,6 @@
 # V2 Roadmap and Issue Tracker
 
-Updated: 2026-03-05
+Updated: 2026-03-08
 Owner: Product + Engineering
 Status: Execution tracker
 
@@ -47,7 +47,7 @@ Epic issues are now created and linked below.
 | E1 | [#3](https://github.com/itprodirect/safe-link-project/issues/3) | V2 Foundation: composition root, service layer, `/api/v2` skeleton | V2-Phase-1 | Open |
 | E2 | [#4](https://github.com/itprodirect/safe-link-project/issues/4) | V2 Unified Analyze Workspace (URL/Email/QR) | V2-Phase-2 | Open |
 | E3 | [#5](https://github.com/itprodirect/safe-link-project/issues/5) | V2 Verdict-First UX and action flow | V2-Phase-3 | Open |
-| E4 | [#6](https://github.com/itprodirect/safe-link-project/issues/6) | V2 Analyst Mode and deep evidence surfaces | V2-Phase-4 | Open |
+| E4 | [#6](https://github.com/itprodirect/safe-link-project/issues/6) | V2 Analyst Mode and deep evidence surfaces | V2-Phase-4 | Ready to close |
 | E5 | [#7](https://github.com/itprodirect/safe-link-project/issues/7) | V2 Policy Packs and suppression management | V2-Phase-5 | Open |
 | E6 | [#8](https://github.com/itprodirect/safe-link-project/issues/8) | V2 History, compare, and feedback loop | V2-Phase-6 | Open |
 | E7 | [#9](https://github.com/itprodirect/safe-link-project/issues/9) | V2 Hardening: security, reliability, observability | V2-Phase-7 | Open |
@@ -124,16 +124,17 @@ Epic issues are now created and linked below.
 
 ### Child issues
 
-- [ ] `E4-I1` Implement `EvidencePanel` with filtering.
-- [ ] `E4-I2` Implement `DomainAnatomy` component.
-- [ ] `E4-I3` Implement `RedirectPathView`.
-- [ ] `E4-I4` Add suppression trace visibility.
-- [ ] `E4-I5` Add compare-ready evidence model in API output.
+- [x] `E4-I1` Implement `EvidencePanel` with filtering.
+- [x] `E4-I2` Implement `DomainAnatomy` component.
+- [x] `E4-I3` Implement `RedirectPathView`.
+- [x] `E4-I4` Add suppression trace visibility.
+- [x] `E4-I5` Add compare-ready evidence model in API output.
 
 ### Definition of done
 
 1. Analysts can inspect full evidence and derivation path.
-2. Quick mode remains uncluttered.
+2. Suppressed findings and compare-stable evidence keys are available in the v2 URL contract.
+3. Quick mode remains uncluttered.
 
 ## E5: Policy Packs
 

--- a/docs/issues/V2_E4_ANALYST_MODE.md
+++ b/docs/issues/V2_E4_ANALYST_MODE.md
@@ -3,6 +3,7 @@
 Parent Epic: #2
 Milestone: `V2-Phase-4`
 Labels: `v2`, `epic`, `frontend`, `backend`, `ux`
+Status: Locally complete in PR #13 (`codex/analyst-mode-url-slice`)
 
 ## Summary
 
@@ -13,19 +14,22 @@ Provide deep inspection tools for analysts without overwhelming Quick mode users
 1. Add evidence-focused analyst components and filters.
 2. Expose structured domain anatomy and redirect path insights.
 3. Make suppression traces visible in analyst output.
+4. Add compare-ready evidence keys to the v2 analyst contract for future history/delta views.
 
 ## Checklist
 
-- [ ] Build `EvidencePanel` with filtering and search.
-- [ ] Build `DomainAnatomy` visual component.
-- [ ] Build `RedirectPathView` timeline.
-- [ ] Add suppression trace visibility in API/UI.
-- [ ] Add analyst-mode behavior tests.
+- [x] Build `EvidencePanel` with filtering and search.
+- [x] Build `DomainAnatomy` visual component.
+- [x] Build `RedirectPathView` timeline.
+- [x] Add suppression trace visibility in API/UI.
+- [x] Add compare-ready evidence model in API output.
+- [x] Add analyst-mode behavior tests.
 
 ## Definition of Done
 
 1. Analysts can inspect full finding provenance in-app.
-2. Quick mode remains uncluttered and focused on decision output.
+2. URL analyst output includes suppression traces and compare-stable evidence keys.
+3. Quick mode remains uncluttered and focused on decision output.
 
 ## References
 

--- a/src/lsh/adapters/api.py
+++ b/src/lsh/adapters/api.py
@@ -211,7 +211,7 @@ def create_app() -> Any:
             include_family=request.family,
         )
 
-    @app.post("/api/v2/analyze", response_model=AnalyzeV2Response)
+    @app.post("/api/v2/analyze", response_model=AnalyzeV2Response, response_model_exclude_none=True)
     def analyze_v2(request: AnalyzeRequestV2) -> dict[str, object]:
         if request.input_type == "url":
             result = analyze_url(
@@ -338,4 +338,5 @@ def create_app() -> Any:
 
 
 app: Any | None = create_app() if FASTAPI_AVAILABLE else None
+
 

--- a/src/lsh/adapters/api_models.py
+++ b/src/lsh/adapters/api_models.py
@@ -72,10 +72,31 @@ class RedirectTracePayload(_StrictModel):
     request_error: str | None = None
 
 
+class SuppressionTraceRowPayload(_StrictModel):
+    module: str
+    category: str
+    hostname: str
+    matched_allowlist_domain: str
+    suppression_scope: Literal["category", "finding"]
+    matched_rule: str
+    reason: str
+
+
+class SuppressionTracePayload(_StrictModel):
+    hostname: str | None = None
+    configured_allowlist_domains: list[str]
+    configured_allowlist_categories: list[str]
+    configured_allowlist_findings: list[str]
+    matched_allowlist_domains: list[str]
+    suppressed_count: int = Field(ge=0)
+    suppressed_rows: list[SuppressionTraceRowPayload]
+
+
 class UrlAnalystPayload(_StrictModel):
     domain_anatomy: DomainAnatomyPayload
     evidence_rows: list[AnalystEvidenceRowPayload]
     redirect_trace: RedirectTracePayload | None = None
+    suppression_trace: SuppressionTracePayload | None = None
 
 
 class WrappedItem(_StrictModel):

--- a/src/lsh/adapters/api_models.py
+++ b/src/lsh/adapters/api_models.py
@@ -22,10 +22,70 @@ class FamilyPayload(_StrictModel):
     recommendations: list[str]
 
 
+class EvidenceValuePayload(_StrictModel):
+    label: str
+    value: str
+
+
+class AnalystEvidenceRowPayload(_StrictModel):
+    module: str
+    category: str
+    severity: str
+    confidence: str
+    cumulative_risk_score: int
+    title: str
+    explanation: str
+    family_explanation: str
+    recommendations: list[str]
+    evidence: list[EvidenceValuePayload]
+
+
+class DomainAnatomyPayload(_StrictModel):
+    submitted_url: str
+    canonical_url: str
+    hostname: str | None = None
+    canonical_hostname: str | None = None
+    registrable_domain: str | None = None
+    canonical_registrable_domain: str | None = None
+    subdomain_labels: list[str]
+    registrable_labels: list[str]
+    idna_ascii_hostname: str | None = None
+    idna_unicode_hostname: str | None = None
+    is_ip_literal: bool
+    ip_literal: str | None = None
+    obfuscated_ipv4: str | None = None
+    obfuscated_ipv4_notes: list[str]
+    ipv6_mapped_ipv4: str | None = None
+    normalization_notes: list[str]
+
+
+class RedirectTracePayload(_StrictModel):
+    hops: list[str]
+    start_url: str
+    final_url: str
+    registrable_domain_path: list[str]
+    hop_count: int = Field(ge=0)
+    crosses_registrable_domain: bool
+    max_hops_reached: bool
+    timed_out: bool
+    loop_target: str | None = None
+    request_error: str | None = None
+
+
+class UrlAnalystPayload(_StrictModel):
+    domain_anatomy: DomainAnatomyPayload
+    evidence_rows: list[AnalystEvidenceRowPayload]
+    redirect_trace: RedirectTracePayload | None = None
+
+
 class WrappedItem(_StrictModel):
     subject: str
     result: AnalysisResult
     family: FamilyPayload | None = None
+
+
+class WrappedItemV2(WrappedItem):
+    analyst: UrlAnalystPayload | None = None
 
 
 class UrlCheckResponse(_StrictModel):
@@ -52,7 +112,7 @@ class AnalyzeV2Response(_StrictModel):
     mode: Literal["single"]
     input_type: Literal["url", "email_headers", "email_file"]
     item_count: Literal[1]
-    item: WrappedItem
+    item: WrappedItemV2
 
 
 class QRLegacyResultItem(_StrictModel):

--- a/src/lsh/adapters/api_models.py
+++ b/src/lsh/adapters/api_models.py
@@ -23,6 +23,7 @@ class FamilyPayload(_StrictModel):
 
 
 class EvidenceValuePayload(_StrictModel):
+    key: str
     label: str
     value: str
 
@@ -30,14 +31,19 @@ class EvidenceValuePayload(_StrictModel):
 class AnalystEvidenceRowPayload(_StrictModel):
     module: str
     category: str
+    finding_key: str
+    compare_key: str
+    sort_index: int = Field(ge=0)
     severity: str
     confidence: str
     cumulative_risk_score: int
+    risk_delta: int | None = None
     title: str
     explanation: str
     family_explanation: str
     recommendations: list[str]
     evidence: list[EvidenceValuePayload]
+    evidence_map: dict[str, str]
 
 
 class DomainAnatomyPayload(_StrictModel):
@@ -75,6 +81,9 @@ class RedirectTracePayload(_StrictModel):
 class SuppressionTraceRowPayload(_StrictModel):
     module: str
     category: str
+    finding_key: str
+    compare_key: str
+    sort_index: int = Field(ge=0)
     hostname: str
     matched_allowlist_domain: str
     suppression_scope: Literal["category", "finding"]

--- a/src/lsh/core/allowlist.py
+++ b/src/lsh/core/allowlist.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from urllib.parse import urlparse
 
+from lsh.core.context import SuppressionTraceEvent, append_suppression_trace_event
 from lsh.core.models import AnalysisInput
 from lsh.core.url_tools import normalize_hostname
 
@@ -118,17 +119,27 @@ def allowlist_findings_for_input(analysis_input: AnalysisInput) -> set[str]:
     return {finding.strip().upper() for finding in raw_findings if finding.strip()}
 
 
-def is_hostname_allowlisted(hostname: str, allowlist_domains: set[str]) -> bool:
-    """Check exact/suffix match against allowlist with IDNA form expansion."""
+def matching_allowlist_domain(hostname: str, allowlist_domains: set[str]) -> str | None:
+    """Return the most specific allowlist domain that matches this hostname."""
     if not allowlist_domains:
-        return False
+        return None
 
+    matches: set[str] = set()
     host_forms = _expanded_domain_forms(hostname)
     for host in host_forms:
         for allowed in allowlist_domains:
             if host == allowed or host.endswith(f".{allowed}"):
-                return True
-    return False
+                matches.add(allowed)
+
+    if not matches:
+        return None
+
+    return sorted(matches, key=lambda domain: (-len(domain), domain))[0]
+
+
+def is_hostname_allowlisted(hostname: str, allowlist_domains: set[str]) -> bool:
+    """Check exact/suffix match against allowlist with IDNA form expansion."""
+    return matching_allowlist_domain(hostname, allowlist_domains) is not None
 
 
 def should_suppress_for_allowlist(
@@ -143,7 +154,8 @@ def should_suppress_for_allowlist(
         return False
 
     allowlist_domains = allowlist_domains_for_input(analysis_input)
-    if not is_hostname_allowlisted(hostname, allowlist_domains):
+    matched_domain = matching_allowlist_domain(hostname, allowlist_domains)
+    if matched_domain is None:
         return False
 
     categories = allowlist_category_prefixes_for_input(analysis_input)
@@ -165,10 +177,46 @@ def _finding_token_matches(code: str, token: str) -> bool:
     return code.startswith(f"{token}_")
 
 
+def _matching_finding_token(code: str, finding_tokens: set[str]) -> str | None:
+    for token in sorted(
+        finding_tokens,
+        key=lambda value: (-len(value.removesuffix("*")), value.endswith("*"), value),
+    ):
+        if _finding_token_matches(code, token):
+            return token
+    return None
+
+
+def _record_suppression_event(
+    analysis_input: AnalysisInput,
+    *,
+    module_name: str,
+    hostname: str,
+    finding_code: str,
+    category_prefix: str,
+    matched_allowlist_domain: str,
+    suppression_scope: str,
+    matched_rule: str,
+) -> None:
+    append_suppression_trace_event(
+        analysis_input,
+        SuppressionTraceEvent(
+            module=module_name,
+            finding_code=finding_code,
+            category_prefix=category_prefix,
+            hostname=hostname,
+            matched_allowlist_domain=matched_allowlist_domain,
+            suppression_scope=suppression_scope,
+            matched_rule=matched_rule,
+        ),
+    )
+
+
 def should_suppress_finding_for_allowlist(
     analysis_input: AnalysisInput,
     hostname: str,
     *,
+    module_name: str | None = None,
     category_prefix: str,
     finding_code: str,
 ) -> bool:
@@ -178,16 +226,42 @@ def should_suppress_finding_for_allowlist(
         return False
 
     allowlist_domains = allowlist_domains_for_input(analysis_input)
-    if not is_hostname_allowlisted(hostname, allowlist_domains):
+    matched_domain = matching_allowlist_domain(hostname, allowlist_domains)
+    if matched_domain is None:
         return False
-
-    categories = allowlist_category_prefixes_for_input(analysis_input)
-    if category in categories:
-        return True
 
     code = finding_code.strip().upper()
     if not code:
         return False
 
+    resolved_module = module_name or category.lower()
+    categories = allowlist_category_prefixes_for_input(analysis_input)
+    if category in categories:
+        _record_suppression_event(
+            analysis_input,
+            module_name=resolved_module,
+            hostname=hostname,
+            finding_code=code,
+            category_prefix=category,
+            matched_allowlist_domain=matched_domain,
+            suppression_scope="category",
+            matched_rule=category,
+        )
+        return True
+
     finding_tokens = allowlist_findings_for_input(analysis_input)
-    return any(_finding_token_matches(code, token) for token in finding_tokens)
+    matched_token = _matching_finding_token(code, finding_tokens)
+    if matched_token is None:
+        return False
+
+    _record_suppression_event(
+        analysis_input,
+        module_name=resolved_module,
+        hostname=hostname,
+        finding_code=code,
+        category_prefix=category,
+        matched_allowlist_domain=matched_domain,
+        suppression_scope="finding",
+        matched_rule=matched_token,
+    )
+    return True

--- a/src/lsh/core/context.py
+++ b/src/lsh/core/context.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from ipaddress import IPv4Address
 from typing import cast
 from urllib.parse import ParseResult
@@ -53,10 +53,24 @@ class URLAnalysisContext:
 
 
 @dataclass(slots=True)
+class SuppressionTraceEvent:
+    """Runtime-only record of one allowlist suppression decision."""
+
+    module: str
+    finding_code: str
+    category_prefix: str
+    hostname: str
+    matched_allowlist_domain: str
+    suppression_scope: str
+    matched_rule: str
+
+
+@dataclass(slots=True)
 class AnalysisRuntimeContext:
     """Runtime-only context attached to `AnalysisInput` (not serialized)."""
 
     url: URLAnalysisContext | None = None
+    suppressed_findings: list[SuppressionTraceEvent] = field(default_factory=list)
 
 
 def _build_url_context(raw_url: str) -> URLAnalysisContext:
@@ -127,6 +141,18 @@ def get_runtime_context(analysis_input: AnalysisInput) -> AnalysisRuntimeContext
     if context is None:
         return None
     return cast(AnalysisRuntimeContext, context)
+
+
+def append_suppression_trace_event(
+    analysis_input: AnalysisInput,
+    event: SuppressionTraceEvent,
+) -> None:
+    """Attach one suppression event to the input runtime context."""
+    runtime_context = get_runtime_context(analysis_input)
+    if runtime_context is None:
+        runtime_context = build_runtime_context(analysis_input)
+        set_runtime_context(analysis_input, runtime_context)
+    runtime_context.suppressed_findings.append(event)
 
 
 def url_context_for_input(analysis_input: AnalysisInput) -> URLAnalysisContext | None:

--- a/src/lsh/formatters/structured.py
+++ b/src/lsh/formatters/structured.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from lsh.core.context import url_context_for_input
 from lsh.core.models import AnalysisResult
+from lsh.core.url_tools import extract_hostname, registrable_domain, registrable_labels
 from lsh.formatters.family import build_family_view
 
 
@@ -22,11 +24,161 @@ def _family_payload(result: AnalysisResult) -> dict[str, object]:
     }
 
 
+def _finding_evidence_payload(result: AnalysisResult) -> list[dict[str, object]]:
+    findings = sorted(
+        result.findings,
+        key=lambda finding: (-finding.risk_score, finding.module, finding.category, finding.title),
+    )
+    return [
+        {
+            "module": finding.module,
+            "category": finding.category,
+            "severity": finding.severity.value,
+            "confidence": finding.confidence.value,
+            "cumulative_risk_score": finding.risk_score,
+            "title": finding.title,
+            "explanation": finding.explanation,
+            "family_explanation": finding.family_explanation,
+            "recommendations": list(finding.recommendations),
+            "evidence": [
+                {"label": evidence.label, "value": evidence.value} for evidence in finding.evidence
+            ],
+        }
+        for finding in findings
+    ]
+
+
+def _split_chain(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [segment.strip() for segment in value.split(" -> ") if segment.strip()]
+
+
+def _redirect_trace_payload(result: AnalysisResult) -> dict[str, object] | None:
+    redirect_findings = [finding for finding in result.findings if finding.module == "redirect"]
+    if not redirect_findings:
+        return None
+
+    chain: list[str] = []
+    start_url: str | None = None
+    final_url: str | None = None
+    registrable_domain_path: list[str] = []
+    hop_count = 0
+    loop_target: str | None = None
+    request_error: str | None = None
+
+    for finding in redirect_findings:
+        evidence_map = {evidence.label: evidence.value for evidence in finding.evidence}
+        if not chain:
+            chain = _split_chain(evidence_map.get("Chain"))
+        if start_url is None:
+            start_url = evidence_map.get("Start URL")
+        if final_url is None:
+            final_url = evidence_map.get("Final URL")
+        if not registrable_domain_path:
+            registrable_domain_path = _split_chain(evidence_map.get("Domain Path"))
+        if hop_count == 0:
+            raw_hops = evidence_map.get("Redirect Hops")
+            if raw_hops is not None:
+                try:
+                    hop_count = int(raw_hops)
+                except ValueError:
+                    hop_count = 0
+        if loop_target is None:
+            loop_target = evidence_map.get("Loop Target")
+        if request_error is None:
+            request_error = evidence_map.get("Error")
+
+    if not chain:
+        chain = [value for value in (start_url, final_url) if value]
+    if chain:
+        start_url = start_url or chain[0]
+        final_url = final_url or chain[-1]
+        hop_count = max(hop_count, len(chain) - 1)
+
+    if not registrable_domain_path and chain:
+        for url in chain:
+            hostname = extract_hostname(url)
+            if hostname is None:
+                continue
+            registrable_domain_path.append(registrable_domain(hostname))
+
+    if start_url is None or final_url is None:
+        return None
+
+    categories = {finding.category for finding in redirect_findings}
+    return {
+        "hops": chain,
+        "start_url": start_url,
+        "final_url": final_url,
+        "registrable_domain_path": registrable_domain_path,
+        "hop_count": hop_count,
+        "crosses_registrable_domain": "RED002_CROSS_DOMAIN_REDIRECT" in categories
+        or len({domain for domain in registrable_domain_path if domain}) >= 2,
+        "max_hops_reached": "RED003_MAX_HOPS_REACHED" in categories,
+        "timed_out": "RED005_REQUEST_TIMEOUT" in categories,
+        "loop_target": loop_target,
+        "request_error": request_error,
+    }
+
+
+def _domain_anatomy_payload(result: AnalysisResult) -> dict[str, object] | None:
+    url_context = url_context_for_input(result.input)
+    if url_context is None:
+        return None
+
+    hostname_labels = [label for label in (url_context.hostname or "").split(".") if label]
+    registrable = url_context.registrable_domain or ""
+    registrable_parts = registrable_labels(registrable) if registrable else []
+    registrable_label_count = len(registrable_parts)
+    if registrable_label_count and len(hostname_labels) > registrable_label_count:
+        subdomain_labels = hostname_labels[:-registrable_label_count]
+    else:
+        subdomain_labels = []
+
+    return {
+        "submitted_url": url_context.raw_url,
+        "canonical_url": url_context.normalized_url.canonical,
+        "hostname": url_context.hostname,
+        "canonical_hostname": url_context.canonical_hostname,
+        "registrable_domain": url_context.registrable_domain,
+        "canonical_registrable_domain": url_context.canonical_registrable_domain,
+        "subdomain_labels": subdomain_labels,
+        "registrable_labels": registrable_parts,
+        "idna_ascii_hostname": url_context.idna_ascii_hostname,
+        "idna_unicode_hostname": url_context.idna_unicode_hostname,
+        "is_ip_literal": url_context.ip_literal is not None,
+        "ip_literal": str(url_context.ip_literal) if url_context.ip_literal is not None else None,
+        "obfuscated_ipv4": (
+            str(url_context.obfuscated_ipv4) if url_context.obfuscated_ipv4 is not None else None
+        ),
+        "obfuscated_ipv4_notes": list(url_context.obfuscated_ipv4_notes),
+        "ipv6_mapped_ipv4": (
+            str(url_context.ipv6_mapped_ipv4) if url_context.ipv6_mapped_ipv4 is not None else None
+        ),
+        "normalization_notes": list(url_context.normalized_url.normalization_notes),
+    }
+
+
+def _url_analyst_payload(result: AnalysisResult) -> dict[str, object] | None:
+    domain_anatomy = _domain_anatomy_payload(result)
+    if domain_anatomy is None:
+        return None
+
+    return {
+        "domain_anatomy": domain_anatomy,
+        "evidence_rows": _finding_evidence_payload(result),
+        "redirect_trace": _redirect_trace_payload(result),
+    }
+
+
 def _item_payload(
     *,
+    input_type: str,
     subject: str,
     result: AnalysisResult,
     include_family: bool,
+    include_analyst: bool,
 ) -> dict[str, object]:
     item: dict[str, object] = {
         "subject": subject,
@@ -34,6 +186,10 @@ def _item_payload(
     }
     if include_family:
         item["family"] = _family_payload(result)
+    if include_analyst and input_type == "url":
+        analyst = _url_analyst_payload(result)
+        if analyst is not None:
+            item["analyst"] = analyst
     return item
 
 
@@ -45,9 +201,20 @@ def build_single_result_payload(
     result: AnalysisResult,
     include_family: bool = False,
     schema_version: str = "1.0",
+    include_analyst: bool | None = None,
 ) -> dict[str, object]:
     """Build a stable single-item payload shape for API/JSON consumers."""
-    item = _item_payload(subject=subject, result=result, include_family=include_family)
+    if include_analyst is None:
+        resolved_include_analyst = schema_version == "2.0" and input_type == "url"
+    else:
+        resolved_include_analyst = include_analyst and input_type == "url"
+    item = _item_payload(
+        input_type=input_type,
+        subject=subject,
+        result=result,
+        include_family=include_family,
+        include_analyst=resolved_include_analyst,
+    )
     return {
         "schema_version": schema_version,
         "flow": flow,
@@ -65,10 +232,17 @@ def build_multi_result_payload(
     items: list[tuple[str, AnalysisResult]],
     include_family: bool = False,
     schema_version: str = "1.0",
+    include_analyst: bool = False,
 ) -> dict[str, object]:
     """Build a stable multi-item payload shape for batch-like workflows."""
     payload_items = [
-        _item_payload(subject=subject, result=result, include_family=include_family)
+        _item_payload(
+            input_type=input_type,
+            subject=subject,
+            result=result,
+            include_family=include_family,
+            include_analyst=include_analyst and input_type == "url",
+        )
         for subject, result in items
     ]
     return {

--- a/src/lsh/formatters/structured.py
+++ b/src/lsh/formatters/structured.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
+import re
+
 from lsh.core.allowlist import (
     allowlist_category_prefixes_for_input,
     allowlist_domains_for_input,
     allowlist_findings_for_input,
 )
 from lsh.core.context import get_runtime_context, url_context_for_input
-from lsh.core.models import AnalysisResult
+from lsh.core.models import AnalysisResult, Finding
 from lsh.core.url_tools import extract_hostname, registrable_domain, registrable_labels
 from lsh.formatters.family import build_family_view
+
+_COMPARE_TOKEN_PATTERN = re.compile(r"[^a-z0-9]+")
+_RISK_DELTA_PATTERN = re.compile(r"^[+]?(?P<value>-?\d+)$")
 
 
 def _analysis_result_payload(result: AnalysisResult) -> dict[str, object]:
@@ -29,28 +34,78 @@ def _family_payload(result: AnalysisResult) -> dict[str, object]:
     }
 
 
+def _compare_token(value: str) -> str:
+    token = _COMPARE_TOKEN_PATTERN.sub("_", value.strip().lower()).strip("_")
+    return token or "value"
+
+
+def _stable_compare_key(base_key: str, seen_keys: dict[str, int]) -> str:
+    occurrence = seen_keys.get(base_key, 0) + 1
+    seen_keys[base_key] = occurrence
+    if occurrence == 1:
+        return base_key
+    return f"{base_key}#{occurrence}"
+
+
+def _evidence_payload(finding: Finding) -> tuple[list[dict[str, str]], dict[str, str]]:
+    evidence_entries = []
+    evidence_map: dict[str, str] = {}
+    seen_keys: dict[str, int] = {}
+
+    for evidence in finding.evidence:
+        base_key = _compare_token(evidence.label)
+        compare_key = _stable_compare_key(base_key, seen_keys)
+        evidence_entries.append(
+            {"key": compare_key, "label": evidence.label, "value": evidence.value}
+        )
+        evidence_map[compare_key] = evidence.value
+
+    return evidence_entries, evidence_map
+
+
+def _risk_delta_value(evidence_map: dict[str, str]) -> int | None:
+    raw_value = evidence_map.get("risk_delta")
+    if raw_value is None:
+        return None
+    match = _RISK_DELTA_PATTERN.match(raw_value.strip())
+    if match is None:
+        return None
+    return int(match.group("value"))
+
+
 def _finding_evidence_payload(result: AnalysisResult) -> list[dict[str, object]]:
     findings = sorted(
         result.findings,
         key=lambda finding: (-finding.risk_score, finding.module, finding.category, finding.title),
     )
-    return [
-        {
-            "module": finding.module,
-            "category": finding.category,
-            "severity": finding.severity.value,
-            "confidence": finding.confidence.value,
-            "cumulative_risk_score": finding.risk_score,
-            "title": finding.title,
-            "explanation": finding.explanation,
-            "family_explanation": finding.family_explanation,
-            "recommendations": list(finding.recommendations),
-            "evidence": [
-                {"label": evidence.label, "value": evidence.value} for evidence in finding.evidence
-            ],
-        }
-        for finding in findings
-    ]
+    rows: list[dict[str, object]] = []
+    seen_keys: dict[str, int] = {}
+
+    for index, finding in enumerate(findings):
+        finding_key = f"{finding.module}:{finding.category}"
+        compare_key = _stable_compare_key(finding_key, seen_keys)
+        evidence_entries, evidence_map = _evidence_payload(finding)
+        rows.append(
+            {
+                "module": finding.module,
+                "category": finding.category,
+                "finding_key": finding_key,
+                "compare_key": compare_key,
+                "sort_index": index,
+                "severity": finding.severity.value,
+                "confidence": finding.confidence.value,
+                "cumulative_risk_score": finding.risk_score,
+                "risk_delta": _risk_delta_value(evidence_map),
+                "title": finding.title,
+                "explanation": finding.explanation,
+                "family_explanation": finding.family_explanation,
+                "recommendations": list(finding.recommendations),
+                "evidence": evidence_entries,
+                "evidence_map": evidence_map,
+            }
+        )
+
+    return rows
 
 
 def _split_chain(value: str | None) -> list[str]:
@@ -177,8 +232,45 @@ def _suppression_reason(scope: str, *, matched_rule: str) -> str:
     )
 
 
-def _suppression_trace_payload(result: AnalysisResult) -> dict[str, object] | None:
+def _suppression_rows_payload(result: AnalysisResult) -> list[dict[str, object]]:
     runtime_context = get_runtime_context(result.input)
+    suppressed_events = [] if runtime_context is None else list(runtime_context.suppressed_findings)
+    seen_keys: dict[str, int] = {}
+    rows: list[dict[str, object]] = []
+
+    for index, event in enumerate(
+        sorted(
+            suppressed_events,
+            key=lambda value: (value.module, value.finding_code, value.matched_rule),
+        )
+    ):
+        finding_key = f"{event.module}:{event.finding_code}"
+        base_compare_key = (
+            f"{finding_key}:{event.suppression_scope}:{_compare_token(event.matched_rule)}"
+        )
+        compare_key = _stable_compare_key(base_compare_key, seen_keys)
+        rows.append(
+            {
+                "module": event.module,
+                "category": event.finding_code,
+                "finding_key": finding_key,
+                "compare_key": compare_key,
+                "sort_index": index,
+                "hostname": event.hostname,
+                "matched_allowlist_domain": event.matched_allowlist_domain,
+                "suppression_scope": event.suppression_scope,
+                "matched_rule": event.matched_rule,
+                "reason": _suppression_reason(
+                    event.suppression_scope,
+                    matched_rule=event.matched_rule,
+                ),
+            }
+        )
+
+    return rows
+
+
+def _suppression_trace_payload(result: AnalysisResult) -> dict[str, object] | None:
     url_context = url_context_for_input(result.input)
     configured_domains = sorted(allowlist_domains_for_input(result.input))
     if not configured_domains:
@@ -186,25 +278,7 @@ def _suppression_trace_payload(result: AnalysisResult) -> dict[str, object] | No
 
     configured_categories = sorted(allowlist_category_prefixes_for_input(result.input))
     configured_findings = sorted(allowlist_findings_for_input(result.input))
-    suppressed_events = [] if runtime_context is None else list(runtime_context.suppressed_findings)
-    suppressed_rows = [
-        {
-            "module": event.module,
-            "category": event.finding_code,
-            "hostname": event.hostname,
-            "matched_allowlist_domain": event.matched_allowlist_domain,
-            "suppression_scope": event.suppression_scope,
-            "matched_rule": event.matched_rule,
-            "reason": _suppression_reason(
-                event.suppression_scope,
-                matched_rule=event.matched_rule,
-            ),
-        }
-        for event in sorted(
-            suppressed_events,
-            key=lambda value: (value.module, value.finding_code, value.matched_rule),
-        )
-    ]
+    suppressed_rows = _suppression_rows_payload(result)
     matched_domains = sorted(
         {
             row["matched_allowlist_domain"]

--- a/src/lsh/formatters/structured.py
+++ b/src/lsh/formatters/structured.py
@@ -281,9 +281,10 @@ def _suppression_trace_payload(result: AnalysisResult) -> dict[str, object] | No
     suppressed_rows = _suppression_rows_payload(result)
     matched_domains = sorted(
         {
-            row["matched_allowlist_domain"]
+            matched_domain
             for row in suppressed_rows
-            if row["matched_allowlist_domain"]
+            for matched_domain in [row.get("matched_allowlist_domain")]
+            if isinstance(matched_domain, str) and matched_domain
         }
     )
 

--- a/src/lsh/formatters/structured.py
+++ b/src/lsh/formatters/structured.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from lsh.core.context import url_context_for_input
+from lsh.core.allowlist import (
+    allowlist_category_prefixes_for_input,
+    allowlist_domains_for_input,
+    allowlist_findings_for_input,
+)
+from lsh.core.context import get_runtime_context, url_context_for_input
 from lsh.core.models import AnalysisResult
 from lsh.core.url_tools import extract_hostname, registrable_domain, registrable_labels
 from lsh.formatters.family import build_family_view
@@ -160,6 +165,65 @@ def _domain_anatomy_payload(result: AnalysisResult) -> dict[str, object] | None:
     }
 
 
+def _suppression_reason(scope: str, *, matched_rule: str) -> str:
+    if scope == "category":
+        return (
+            "Suppressed because the hostname matched an allowlist domain and "
+            f"category prefix {matched_rule} was enabled."
+        )
+    return (
+        "Suppressed because the hostname matched an allowlist domain and "
+        f"finding token {matched_rule} was enabled."
+    )
+
+
+def _suppression_trace_payload(result: AnalysisResult) -> dict[str, object] | None:
+    runtime_context = get_runtime_context(result.input)
+    url_context = url_context_for_input(result.input)
+    configured_domains = sorted(allowlist_domains_for_input(result.input))
+    if not configured_domains:
+        return None
+
+    configured_categories = sorted(allowlist_category_prefixes_for_input(result.input))
+    configured_findings = sorted(allowlist_findings_for_input(result.input))
+    suppressed_events = [] if runtime_context is None else list(runtime_context.suppressed_findings)
+    suppressed_rows = [
+        {
+            "module": event.module,
+            "category": event.finding_code,
+            "hostname": event.hostname,
+            "matched_allowlist_domain": event.matched_allowlist_domain,
+            "suppression_scope": event.suppression_scope,
+            "matched_rule": event.matched_rule,
+            "reason": _suppression_reason(
+                event.suppression_scope,
+                matched_rule=event.matched_rule,
+            ),
+        }
+        for event in sorted(
+            suppressed_events,
+            key=lambda value: (value.module, value.finding_code, value.matched_rule),
+        )
+    ]
+    matched_domains = sorted(
+        {
+            row["matched_allowlist_domain"]
+            for row in suppressed_rows
+            if row["matched_allowlist_domain"]
+        }
+    )
+
+    return {
+        "hostname": None if url_context is None else url_context.hostname,
+        "configured_allowlist_domains": configured_domains,
+        "configured_allowlist_categories": configured_categories,
+        "configured_allowlist_findings": configured_findings,
+        "matched_allowlist_domains": matched_domains,
+        "suppressed_count": len(suppressed_rows),
+        "suppressed_rows": suppressed_rows,
+    }
+
+
 def _url_analyst_payload(result: AnalysisResult) -> dict[str, object] | None:
     domain_anatomy = _domain_anatomy_payload(result)
     if domain_anatomy is None:
@@ -169,6 +233,7 @@ def _url_analyst_payload(result: AnalysisResult) -> dict[str, object] | None:
         "domain_anatomy": domain_anatomy,
         "evidence_rows": _finding_evidence_payload(result),
         "redirect_trace": _redirect_trace_payload(result),
+        "suppression_trace": _suppression_trace_payload(result),
     }
 
 

--- a/src/lsh/modules/ascii_lookalike/analyzer.py
+++ b/src/lsh/modules/ascii_lookalike/analyzer.py
@@ -104,6 +104,7 @@ class AsciiLookalikeDetector(ModuleInterface):
             if should_suppress_finding_for_allowlist(
                 input,
                 hostname,
+                module_name=self.name,
                 category_prefix="ASCII",
                 finding_code=code,
             ):

--- a/src/lsh/modules/homoglyph/analyzer.py
+++ b/src/lsh/modules/homoglyph/analyzer.py
@@ -227,6 +227,7 @@ class HomoglyphDetector(ModuleInterface):
             if should_suppress_finding_for_allowlist(
                 input,
                 hostname,
+                module_name=self.name,
                 category_prefix="HMG",
                 finding_code=code,
             ):

--- a/src/lsh/modules/net_ip/analyzer.py
+++ b/src/lsh/modules/net_ip/analyzer.py
@@ -64,6 +64,7 @@ class NetIPDetector(ModuleInterface):
             if should_suppress_finding_for_allowlist(
                 input,
                 hostname,
+                module_name=self.name,
                 category_prefix="NET",
                 finding_code=candidate.category,
             ):

--- a/src/lsh/modules/url_structure/analyzer.py
+++ b/src/lsh/modules/url_structure/analyzer.py
@@ -79,6 +79,7 @@ class URLStructureDetector(ModuleInterface):
             if should_suppress_finding_for_allowlist(
                 input,
                 hostname,
+                module_name=self.name,
                 category_prefix="URL",
                 finding_code=code,
             ):
@@ -218,6 +219,7 @@ class URLStructureDetector(ModuleInterface):
             if fragment_finding is not None and not should_suppress_finding_for_allowlist(
                 input,
                 hostname,
+                module_name=self.name,
                 category_prefix="URL",
                 finding_code=fragment_finding.category,
             ):

--- a/tests/adapters/test_api.py
+++ b/tests/adapters/test_api.py
@@ -198,9 +198,19 @@ def test_v2_analyze_url_allowlist_finding_targets_single_code() -> None:
     assert "HMG002_PUNYCODE_VISIBILITY" not in categories
     assert "HMG003_MIXED_SCRIPT_HOSTNAME" in categories
 
+    evidence_rows = body["item"]["analyst"]["evidence_rows"]
+    assert evidence_rows
+    assert all("compare_key" in row for row in evidence_rows)
+    assert all("finding_key" in row for row in evidence_rows)
+    assert all("evidence_map" in row for row in evidence_rows)
+    assert all("key" in entry for row in evidence_rows for entry in row["evidence"])
+
     suppression_trace = body["item"]["analyst"]["suppression_trace"]
     assert suppression_trace["suppressed_count"] == 1
     assert suppression_trace["suppressed_rows"][0]["category"] == "HMG002_PUNYCODE_VISIBILITY"
+    assert suppression_trace["suppressed_rows"][0]["compare_key"] == (
+        "homoglyph:HMG002_PUNYCODE_VISIBILITY:finding:hmg002_punycode_visibility"
+    )
     assert suppression_trace["suppressed_rows"][0]["suppression_scope"] == "finding"
 
 

--- a/tests/adapters/test_api.py
+++ b/tests/adapters/test_api.py
@@ -141,6 +141,9 @@ def test_v2_analyze_url_returns_wrapped_shape() -> None:
     assert body["mode"] == "single"
     assert body["input_type"] == "url"
     assert body["item_count"] == 1
+    assert "analyst" in body["item"]
+    assert body["item"]["analyst"]["domain_anatomy"]["submitted_url"] == "https://example.com"
+    assert isinstance(body["item"]["analyst"]["evidence_rows"], list)
 
 
 def test_v2_analyze_email_returns_wrapped_shape() -> None:
@@ -159,6 +162,7 @@ def test_v2_analyze_email_returns_wrapped_shape() -> None:
     assert body["flow"] == "analyze"
     assert body["input_type"] == "email_headers"
     assert body["item"]["subject"] == "sample headers"
+    assert "analyst" not in body["item"]
 
 
 def test_v2_analyze_can_include_family_payload() -> None:
@@ -285,6 +289,8 @@ def test_v1_v2_url_result_parity_for_overlapping_fields() -> None:
     )
     assert v1_body["item"]["family"] == v2_body["item"]["family"]
     assert v1_body["item"]["subject"] == v2_body["item"]["subject"]
+    assert "analyst" not in v1_body["item"]
+    assert "analyst" in v2_body["item"]
     assert v1_body["mode"] == v2_body["mode"] == "single"
     assert v1_body["item_count"] == v2_body["item_count"] == 1
 
@@ -527,5 +533,9 @@ def test_qr_scan_requires_upload_file() -> None:
     client = _client()
     response = client.post("/api/v1/qr/scan", data={"analyze_all": "false"})
     assert response.status_code == 422
+
+
+
+
 
 

--- a/tests/adapters/test_api.py
+++ b/tests/adapters/test_api.py
@@ -192,10 +192,16 @@ def test_v2_analyze_url_allowlist_finding_targets_single_code() -> None:
         },
     )
     assert response.status_code == 200
-    findings = response.json()["item"]["result"]["findings"]
+    body = response.json()
+    findings = body["item"]["result"]["findings"]
     categories = {finding["category"] for finding in findings}
     assert "HMG002_PUNYCODE_VISIBILITY" not in categories
     assert "HMG003_MIXED_SCRIPT_HOSTNAME" in categories
+
+    suppression_trace = body["item"]["analyst"]["suppression_trace"]
+    assert suppression_trace["suppressed_count"] == 1
+    assert suppression_trace["suppressed_rows"][0]["category"] == "HMG002_PUNYCODE_VISIBILITY"
+    assert suppression_trace["suppressed_rows"][0]["suppression_scope"] == "finding"
 
 
 def test_v2_analyze_url_allowlist_categories_can_be_lowercase() -> None:

--- a/tests/application/test_analysis_service.py
+++ b/tests/application/test_analysis_service.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 import pytest
 
 from lsh.application import analyze_email, analyze_url
+from lsh.core.context import get_runtime_context
 from lsh.core.models import Severity
 
 
@@ -29,6 +30,26 @@ def test_analyze_url_allowlist_finding_scope_suppresses_only_targeted_code() -> 
     categories = {finding.category for finding in result.findings}
     assert "HMG002_PUNYCODE_VISIBILITY" not in categories
     assert "HMG003_MIXED_SCRIPT_HOSTNAME" in categories
+
+
+def test_analyze_url_records_allowlist_suppression_trace() -> None:
+    result = analyze_url(
+        "https://xn--pple-43d.com",
+        metadata={
+            "allowlist_domains": ["xn--pple-43d.com"],
+            "allowlist_categories": ["NONE"],
+            "allowlist_findings": ["HMG002_PUNYCODE_VISIBILITY"],
+        },
+    )
+
+    runtime_context = get_runtime_context(result.input)
+    assert runtime_context is not None
+    assert len(runtime_context.suppressed_findings) == 1
+    event = runtime_context.suppressed_findings[0]
+    assert event.module == "homoglyph"
+    assert event.finding_code == "HMG002_PUNYCODE_VISIBILITY"
+    assert event.suppression_scope == "finding"
+    assert event.matched_rule == "HMG002_PUNYCODE_VISIBILITY"
 
 
 def test_analyze_email_pass_results_have_no_findings() -> None:

--- a/tests/fixtures/contracts/v1_v2_single_payloads.json
+++ b/tests/fixtures/contracts/v1_v2_single_payloads.json
@@ -1,356 +1,27 @@
 {
-  "url_v1": {
-    "schema_version": "1.0",
-    "flow": "url_check",
-    "mode": "single",
-    "input_type": "url",
-    "item_count": 1,
-    "item": {
-      "subject": "https://xn--pple-43d.com",
-      "result": {
-        "input": {
-          "input_type": "url",
-          "content": "https://xn--pple-43d.com",
-          "metadata": {
-            "allowlist_domains": [
-              "xn--pple-43d.com"
-            ],
-            "allowlist_categories": [
-              "NONE"
-            ],
-            "allowlist_findings": [
-              "HMG002_PUNYCODE_VISIBILITY"
-            ],
-            "network_enabled": false,
-            "network_max_hops": 5,
-            "network_timeout": 3.0
-          }
-        },
-        "findings": [
-          {
-            "module": "homoglyph",
-            "category": "HMG001_NON_ASCII_HOSTNAME",
-            "severity": "LOW",
-            "confidence": "MEDIUM",
-            "risk_score": 25,
-            "title": "Hostname contains non-ASCII characters",
-            "explanation": "The domain includes Unicode characters, so visual lookalike checks are needed to rule out IDN spoofing.",
-            "family_explanation": "This web address uses unusual letters. Some scam links use this trick to look real.",
-            "evidence": [
-              {
-                "label": "Hostname",
-                "value": "\u0430pple.com"
-              },
-              {
-                "label": "Hostname (idna)",
-                "value": "xn--pple-43d.com"
-              },
-              {
-                "label": "Risk Delta",
-                "value": "+25"
-              },
-              {
-                "label": "Cumulative Risk",
-                "value": "25"
-              },
-              {
-                "label": "Signal",
-                "value": "At least one hostname character is outside ASCII."
-              }
-            ],
-            "recommendations": [
-              "Pause before opening this link.",
-              "For important accounts, type the known website address yourself."
-            ]
-          },
-          {
-            "module": "homoglyph",
-            "category": "HMG003_MIXED_SCRIPT_HOSTNAME",
-            "severity": "MEDIUM",
-            "confidence": "HIGH",
-            "risk_score": 60,
-            "title": "Hostname label mixes writing systems",
-            "explanation": "One or more domain labels mix scripts (for example Latin + Cyrillic), which is a common homoglyph phishing pattern.",
-            "family_explanation": "This link mixes different alphabets in one word to look like a known website.",
-            "evidence": [
-              {
-                "label": "Hostname",
-                "value": "\u0430pple.com"
-              },
-              {
-                "label": "Hostname (idna)",
-                "value": "xn--pple-43d.com"
-              },
-              {
-                "label": "Risk Delta",
-                "value": "+35"
-              },
-              {
-                "label": "Cumulative Risk",
-                "value": "60"
-              },
-              {
-                "label": "Label Scripts",
-                "value": "\u0430pple (Cyrillic, Latin)"
-              }
-            ],
-            "recommendations": [
-              "Do not sign in from this link.",
-              "Verify the destination through a trusted app or bookmark."
-            ]
-          },
-          {
-            "module": "homoglyph",
-            "category": "HMG004_CONFUSABLE_CHARACTERS",
-            "severity": "CRITICAL",
-            "confidence": "HIGH",
-            "risk_score": 85,
-            "title": "Confusable hostname characters detected",
-            "explanation": "Unicode confusable analysis found hostname characters that can be read as different ASCII letters/numbers.",
-            "family_explanation": "Some letters in this link can be mistaken for normal English letters or numbers.",
-            "evidence": [
-              {
-                "label": "Hostname",
-                "value": "\u0430pple.com"
-              },
-              {
-                "label": "Hostname (idna)",
-                "value": "xn--pple-43d.com"
-              },
-              {
-                "label": "Risk Delta",
-                "value": "+25"
-              },
-              {
-                "label": "Cumulative Risk",
-                "value": "85"
-              },
-              {
-                "label": "ASCII Lookalike",
-                "value": "apple.com"
-              },
-              {
-                "label": "Character Mapping",
-                "value": "\u0430 -> a"
-              }
-            ],
-            "recommendations": [
-              "Treat this as suspicious until confirmed by a trusted source.",
-              "Use official bookmarks for banking, shopping, and email logins."
-            ]
-          }
-        ],
-        "overall_risk": 94,
-        "overall_severity": "CRITICAL",
-        "summary": "High-risk warning: this link may impersonate a trusted site. Do not open it, and visit the real site by typing the address yourself.",
-        "analyzed_at": "<TIMESTAMP>"
-      },
-      "family": {
-        "risk_score": 94,
-        "severity": "CRITICAL",
-        "summary": "High-risk warning: this link may impersonate a trusted site. Do not open it, and visit the real site by typing the address yourself.",
-        "signal_confidence": "HIGH",
-        "reasons": [
-          "This web address uses unusual letters. Some scam links use this trick to look real.",
-          "This link mixes different alphabets in one word to look like a known website.",
-          "Some letters in this link can be mistaken for normal English letters or numbers."
-        ],
-        "recommendations": [
-          "Pause before opening this link.",
-          "For important accounts, type the known website address yourself.",
-          "Do not sign in from this link."
-        ]
-      }
-    }
-  },
-  "url_v2": {
-    "schema_version": "2.0",
-    "flow": "analyze",
-    "mode": "single",
-    "input_type": "url",
-    "item_count": 1,
-    "item": {
-      "subject": "https://xn--pple-43d.com",
-      "result": {
-        "input": {
-          "input_type": "url",
-          "content": "https://xn--pple-43d.com",
-          "metadata": {
-            "allowlist_domains": [
-              "xn--pple-43d.com"
-            ],
-            "allowlist_categories": [
-              "NONE"
-            ],
-            "allowlist_findings": [
-              "HMG002_PUNYCODE_VISIBILITY"
-            ],
-            "network_enabled": false,
-            "network_max_hops": 5,
-            "network_timeout": 3.0
-          }
-        },
-        "findings": [
-          {
-            "module": "homoglyph",
-            "category": "HMG001_NON_ASCII_HOSTNAME",
-            "severity": "LOW",
-            "confidence": "MEDIUM",
-            "risk_score": 25,
-            "title": "Hostname contains non-ASCII characters",
-            "explanation": "The domain includes Unicode characters, so visual lookalike checks are needed to rule out IDN spoofing.",
-            "family_explanation": "This web address uses unusual letters. Some scam links use this trick to look real.",
-            "evidence": [
-              {
-                "label": "Hostname",
-                "value": "\u0430pple.com"
-              },
-              {
-                "label": "Hostname (idna)",
-                "value": "xn--pple-43d.com"
-              },
-              {
-                "label": "Risk Delta",
-                "value": "+25"
-              },
-              {
-                "label": "Cumulative Risk",
-                "value": "25"
-              },
-              {
-                "label": "Signal",
-                "value": "At least one hostname character is outside ASCII."
-              }
-            ],
-            "recommendations": [
-              "Pause before opening this link.",
-              "For important accounts, type the known website address yourself."
-            ]
-          },
-          {
-            "module": "homoglyph",
-            "category": "HMG003_MIXED_SCRIPT_HOSTNAME",
-            "severity": "MEDIUM",
-            "confidence": "HIGH",
-            "risk_score": 60,
-            "title": "Hostname label mixes writing systems",
-            "explanation": "One or more domain labels mix scripts (for example Latin + Cyrillic), which is a common homoglyph phishing pattern.",
-            "family_explanation": "This link mixes different alphabets in one word to look like a known website.",
-            "evidence": [
-              {
-                "label": "Hostname",
-                "value": "\u0430pple.com"
-              },
-              {
-                "label": "Hostname (idna)",
-                "value": "xn--pple-43d.com"
-              },
-              {
-                "label": "Risk Delta",
-                "value": "+35"
-              },
-              {
-                "label": "Cumulative Risk",
-                "value": "60"
-              },
-              {
-                "label": "Label Scripts",
-                "value": "\u0430pple (Cyrillic, Latin)"
-              }
-            ],
-            "recommendations": [
-              "Do not sign in from this link.",
-              "Verify the destination through a trusted app or bookmark."
-            ]
-          },
-          {
-            "module": "homoglyph",
-            "category": "HMG004_CONFUSABLE_CHARACTERS",
-            "severity": "CRITICAL",
-            "confidence": "HIGH",
-            "risk_score": 85,
-            "title": "Confusable hostname characters detected",
-            "explanation": "Unicode confusable analysis found hostname characters that can be read as different ASCII letters/numbers.",
-            "family_explanation": "Some letters in this link can be mistaken for normal English letters or numbers.",
-            "evidence": [
-              {
-                "label": "Hostname",
-                "value": "\u0430pple.com"
-              },
-              {
-                "label": "Hostname (idna)",
-                "value": "xn--pple-43d.com"
-              },
-              {
-                "label": "Risk Delta",
-                "value": "+25"
-              },
-              {
-                "label": "Cumulative Risk",
-                "value": "85"
-              },
-              {
-                "label": "ASCII Lookalike",
-                "value": "apple.com"
-              },
-              {
-                "label": "Character Mapping",
-                "value": "\u0430 -> a"
-              }
-            ],
-            "recommendations": [
-              "Treat this as suspicious until confirmed by a trusted source.",
-              "Use official bookmarks for banking, shopping, and email logins."
-            ]
-          }
-        ],
-        "overall_risk": 94,
-        "overall_severity": "CRITICAL",
-        "summary": "High-risk warning: this link may impersonate a trusted site. Do not open it, and visit the real site by typing the address yourself.",
-        "analyzed_at": "<TIMESTAMP>"
-      },
-      "family": {
-        "risk_score": 94,
-        "severity": "CRITICAL",
-        "summary": "High-risk warning: this link may impersonate a trusted site. Do not open it, and visit the real site by typing the address yourself.",
-        "signal_confidence": "HIGH",
-        "reasons": [
-          "This web address uses unusual letters. Some scam links use this trick to look real.",
-          "This link mixes different alphabets in one word to look like a known website.",
-          "Some letters in this link can be mistaken for normal English letters or numbers."
-        ],
-        "recommendations": [
-          "Pause before opening this link.",
-          "For important accounts, type the known website address yourself.",
-          "Do not sign in from this link."
-        ]
-      }
-    }
-  },
   "email_v1": {
-    "schema_version": "1.0",
     "flow": "email_check",
-    "mode": "single",
     "input_type": "email_headers",
-    "item_count": 1,
     "item": {
-      "subject": "sample",
+      "family": {
+        "reasons": [
+          "The sender server did not pass a key email authenticity check (SPF)."
+        ],
+        "recommendations": [
+          "Avoid opening links or attachments until sender identity is verified.",
+          "Confirm the message through a separate trusted channel."
+        ],
+        "risk_score": 30,
+        "severity": "LOW",
+        "signal_confidence": "HIGH",
+        "summary": "A mild email authentication warning sign was found. Double-check sensitive requests before taking action."
+      },
       "result": {
-        "input": {
-          "input_type": "email_headers",
-          "content": "Authentication-Results: mx; spf=fail; dkim=pass; dmarc=pass",
-          "metadata": {}
-        },
+        "analyzed_at": "<TIMESTAMP>",
         "findings": [
           {
-            "module": "email_auth",
             "category": "EML101_SPF_FAIL",
-            "severity": "LOW",
             "confidence": "HIGH",
-            "risk_score": 30,
-            "title": "SPF authentication failed",
-            "explanation": "SPF status indicates a failure or DNS/authentication error.",
-            "family_explanation": "The sender server did not pass a key email authenticity check (SPF).",
             "evidence": [
               {
                 "label": "SPF Status",
@@ -381,56 +52,56 @@
                 "value": "30"
               }
             ],
+            "explanation": "SPF status indicates a failure or DNS/authentication error.",
+            "family_explanation": "The sender server did not pass a key email authenticity check (SPF).",
+            "module": "email_auth",
             "recommendations": [
               "Avoid opening links or attachments until sender identity is verified.",
               "Confirm the message through a separate trusted channel."
-            ]
+            ],
+            "risk_score": 30,
+            "severity": "LOW",
+            "title": "SPF authentication failed"
           }
         ],
+        "input": {
+          "content": "Authentication-Results: mx; spf=fail; dkim=pass; dmarc=pass",
+          "input_type": "email_headers",
+          "metadata": {}
+        },
         "overall_risk": 30,
         "overall_severity": "LOW",
-        "summary": "A mild email authentication warning sign was found. Double-check sensitive requests before taking action.",
-        "analyzed_at": "<TIMESTAMP>"
+        "summary": "A mild email authentication warning sign was found. Double-check sensitive requests before taking action."
       },
-      "family": {
-        "risk_score": 30,
-        "severity": "LOW",
-        "summary": "A mild email authentication warning sign was found. Double-check sensitive requests before taking action.",
-        "signal_confidence": "HIGH",
-        "reasons": [
-          "The sender server did not pass a key email authenticity check (SPF)."
-        ],
-        "recommendations": [
-          "Avoid opening links or attachments until sender identity is verified.",
-          "Confirm the message through a separate trusted channel."
-        ]
-      }
-    }
+      "subject": "sample"
+    },
+    "item_count": 1,
+    "mode": "single",
+    "schema_version": "1.0"
   },
   "email_v2": {
-    "schema_version": "2.0",
     "flow": "analyze",
-    "mode": "single",
     "input_type": "email_headers",
-    "item_count": 1,
     "item": {
-      "subject": "sample",
+      "family": {
+        "reasons": [
+          "The sender server did not pass a key email authenticity check (SPF)."
+        ],
+        "recommendations": [
+          "Avoid opening links or attachments until sender identity is verified.",
+          "Confirm the message through a separate trusted channel."
+        ],
+        "risk_score": 30,
+        "severity": "LOW",
+        "signal_confidence": "HIGH",
+        "summary": "A mild email authentication warning sign was found. Double-check sensitive requests before taking action."
+      },
       "result": {
-        "input": {
-          "input_type": "email_headers",
-          "content": "Authentication-Results: mx; spf=fail; dkim=pass; dmarc=pass",
-          "metadata": {}
-        },
+        "analyzed_at": "<TIMESTAMP>",
         "findings": [
           {
-            "module": "email_auth",
             "category": "EML101_SPF_FAIL",
-            "severity": "LOW",
             "confidence": "HIGH",
-            "risk_score": 30,
-            "title": "SPF authentication failed",
-            "explanation": "SPF status indicates a failure or DNS/authentication error.",
-            "family_explanation": "The sender server did not pass a key email authenticity check (SPF).",
             "evidence": [
               {
                 "label": "SPF Status",
@@ -461,30 +132,497 @@
                 "value": "30"
               }
             ],
+            "explanation": "SPF status indicates a failure or DNS/authentication error.",
+            "family_explanation": "The sender server did not pass a key email authenticity check (SPF).",
+            "module": "email_auth",
             "recommendations": [
               "Avoid opening links or attachments until sender identity is verified.",
               "Confirm the message through a separate trusted channel."
-            ]
+            ],
+            "risk_score": 30,
+            "severity": "LOW",
+            "title": "SPF authentication failed"
           }
         ],
+        "input": {
+          "content": "Authentication-Results: mx; spf=fail; dkim=pass; dmarc=pass",
+          "input_type": "email_headers",
+          "metadata": {}
+        },
         "overall_risk": 30,
         "overall_severity": "LOW",
-        "summary": "A mild email authentication warning sign was found. Double-check sensitive requests before taking action.",
-        "analyzed_at": "<TIMESTAMP>"
+        "summary": "A mild email authentication warning sign was found. Double-check sensitive requests before taking action."
       },
+      "subject": "sample"
+    },
+    "item_count": 1,
+    "mode": "single",
+    "schema_version": "2.0"
+  },
+  "url_v1": {
+    "flow": "url_check",
+    "input_type": "url",
+    "item": {
       "family": {
-        "risk_score": 30,
-        "severity": "LOW",
-        "summary": "A mild email authentication warning sign was found. Double-check sensitive requests before taking action.",
-        "signal_confidence": "HIGH",
         "reasons": [
-          "The sender server did not pass a key email authenticity check (SPF)."
+          "This web address uses unusual letters. Some scam links use this trick to look real.",
+          "This link mixes different alphabets in one word to look like a known website.",
+          "Some letters in this link can be mistaken for normal English letters or numbers."
         ],
         "recommendations": [
-          "Avoid opening links or attachments until sender identity is verified.",
-          "Confirm the message through a separate trusted channel."
-        ]
-      }
-    }
+          "Pause before opening this link.",
+          "For important accounts, type the known website address yourself.",
+          "Do not sign in from this link."
+        ],
+        "risk_score": 94,
+        "severity": "CRITICAL",
+        "signal_confidence": "HIGH",
+        "summary": "High-risk warning: this link may impersonate a trusted site. Do not open it, and visit the real site by typing the address yourself."
+      },
+      "result": {
+        "analyzed_at": "<TIMESTAMP>",
+        "findings": [
+          {
+            "category": "HMG001_NON_ASCII_HOSTNAME",
+            "confidence": "MEDIUM",
+            "evidence": [
+              {
+                "label": "Hostname",
+                "value": "\u0430pple.com"
+              },
+              {
+                "label": "Hostname (idna)",
+                "value": "xn--pple-43d.com"
+              },
+              {
+                "label": "Risk Delta",
+                "value": "+25"
+              },
+              {
+                "label": "Cumulative Risk",
+                "value": "25"
+              },
+              {
+                "label": "Signal",
+                "value": "At least one hostname character is outside ASCII."
+              }
+            ],
+            "explanation": "The domain includes Unicode characters, so visual lookalike checks are needed to rule out IDN spoofing.",
+            "family_explanation": "This web address uses unusual letters. Some scam links use this trick to look real.",
+            "module": "homoglyph",
+            "recommendations": [
+              "Pause before opening this link.",
+              "For important accounts, type the known website address yourself."
+            ],
+            "risk_score": 25,
+            "severity": "LOW",
+            "title": "Hostname contains non-ASCII characters"
+          },
+          {
+            "category": "HMG003_MIXED_SCRIPT_HOSTNAME",
+            "confidence": "HIGH",
+            "evidence": [
+              {
+                "label": "Hostname",
+                "value": "\u0430pple.com"
+              },
+              {
+                "label": "Hostname (idna)",
+                "value": "xn--pple-43d.com"
+              },
+              {
+                "label": "Risk Delta",
+                "value": "+35"
+              },
+              {
+                "label": "Cumulative Risk",
+                "value": "60"
+              },
+              {
+                "label": "Label Scripts",
+                "value": "\u0430pple (Cyrillic, Latin)"
+              }
+            ],
+            "explanation": "One or more domain labels mix scripts (for example Latin + Cyrillic), which is a common homoglyph phishing pattern.",
+            "family_explanation": "This link mixes different alphabets in one word to look like a known website.",
+            "module": "homoglyph",
+            "recommendations": [
+              "Do not sign in from this link.",
+              "Verify the destination through a trusted app or bookmark."
+            ],
+            "risk_score": 60,
+            "severity": "MEDIUM",
+            "title": "Hostname label mixes writing systems"
+          },
+          {
+            "category": "HMG004_CONFUSABLE_CHARACTERS",
+            "confidence": "HIGH",
+            "evidence": [
+              {
+                "label": "Hostname",
+                "value": "\u0430pple.com"
+              },
+              {
+                "label": "Hostname (idna)",
+                "value": "xn--pple-43d.com"
+              },
+              {
+                "label": "Risk Delta",
+                "value": "+25"
+              },
+              {
+                "label": "Cumulative Risk",
+                "value": "85"
+              },
+              {
+                "label": "ASCII Lookalike",
+                "value": "apple.com"
+              },
+              {
+                "label": "Character Mapping",
+                "value": "\u0430 -> a"
+              }
+            ],
+            "explanation": "Unicode confusable analysis found hostname characters that can be read as different ASCII letters/numbers.",
+            "family_explanation": "Some letters in this link can be mistaken for normal English letters or numbers.",
+            "module": "homoglyph",
+            "recommendations": [
+              "Treat this as suspicious until confirmed by a trusted source.",
+              "Use official bookmarks for banking, shopping, and email logins."
+            ],
+            "risk_score": 85,
+            "severity": "CRITICAL",
+            "title": "Confusable hostname characters detected"
+          }
+        ],
+        "input": {
+          "content": "https://xn--pple-43d.com",
+          "input_type": "url",
+          "metadata": {
+            "allowlist_categories": [
+              "NONE"
+            ],
+            "allowlist_domains": [
+              "xn--pple-43d.com"
+            ],
+            "allowlist_findings": [
+              "HMG002_PUNYCODE_VISIBILITY"
+            ],
+            "network_enabled": false,
+            "network_max_hops": 5,
+            "network_timeout": 3.0
+          }
+        },
+        "overall_risk": 94,
+        "overall_severity": "CRITICAL",
+        "summary": "High-risk warning: this link may impersonate a trusted site. Do not open it, and visit the real site by typing the address yourself."
+      },
+      "subject": "https://xn--pple-43d.com"
+    },
+    "item_count": 1,
+    "mode": "single",
+    "schema_version": "1.0"
+  },
+  "url_v2": {
+    "flow": "analyze",
+    "input_type": "url",
+    "item": {
+      "analyst": {
+        "domain_anatomy": {
+          "canonical_hostname": "xn--pple-43d.com",
+          "canonical_registrable_domain": "xn--pple-43d.com",
+          "canonical_url": "https://xn--pple-43d.com/",
+          "hostname": "xn--pple-43d.com",
+          "idna_ascii_hostname": "xn--pple-43d.com",
+          "idna_unicode_hostname": "\u0430pple.com",
+          "ip_literal": null,
+          "ipv6_mapped_ipv4": null,
+          "is_ip_literal": false,
+          "normalization_notes": [],
+          "obfuscated_ipv4": null,
+          "obfuscated_ipv4_notes": [],
+          "registrable_domain": "xn--pple-43d.com",
+          "registrable_labels": [
+            "xn--pple-43d",
+            "com"
+          ],
+          "subdomain_labels": [],
+          "submitted_url": "https://xn--pple-43d.com"
+        },
+        "evidence_rows": [
+          {
+            "category": "HMG004_CONFUSABLE_CHARACTERS",
+            "confidence": "HIGH",
+            "cumulative_risk_score": 85,
+            "evidence": [
+              {
+                "label": "Hostname",
+                "value": "\u0430pple.com"
+              },
+              {
+                "label": "Hostname (idna)",
+                "value": "xn--pple-43d.com"
+              },
+              {
+                "label": "Risk Delta",
+                "value": "+25"
+              },
+              {
+                "label": "Cumulative Risk",
+                "value": "85"
+              },
+              {
+                "label": "ASCII Lookalike",
+                "value": "apple.com"
+              },
+              {
+                "label": "Character Mapping",
+                "value": "\u0430 -> a"
+              }
+            ],
+            "explanation": "Unicode confusable analysis found hostname characters that can be read as different ASCII letters/numbers.",
+            "family_explanation": "Some letters in this link can be mistaken for normal English letters or numbers.",
+            "module": "homoglyph",
+            "recommendations": [
+              "Treat this as suspicious until confirmed by a trusted source.",
+              "Use official bookmarks for banking, shopping, and email logins."
+            ],
+            "severity": "CRITICAL",
+            "title": "Confusable hostname characters detected"
+          },
+          {
+            "category": "HMG003_MIXED_SCRIPT_HOSTNAME",
+            "confidence": "HIGH",
+            "cumulative_risk_score": 60,
+            "evidence": [
+              {
+                "label": "Hostname",
+                "value": "\u0430pple.com"
+              },
+              {
+                "label": "Hostname (idna)",
+                "value": "xn--pple-43d.com"
+              },
+              {
+                "label": "Risk Delta",
+                "value": "+35"
+              },
+              {
+                "label": "Cumulative Risk",
+                "value": "60"
+              },
+              {
+                "label": "Label Scripts",
+                "value": "\u0430pple (Cyrillic, Latin)"
+              }
+            ],
+            "explanation": "One or more domain labels mix scripts (for example Latin + Cyrillic), which is a common homoglyph phishing pattern.",
+            "family_explanation": "This link mixes different alphabets in one word to look like a known website.",
+            "module": "homoglyph",
+            "recommendations": [
+              "Do not sign in from this link.",
+              "Verify the destination through a trusted app or bookmark."
+            ],
+            "severity": "MEDIUM",
+            "title": "Hostname label mixes writing systems"
+          },
+          {
+            "category": "HMG001_NON_ASCII_HOSTNAME",
+            "confidence": "MEDIUM",
+            "cumulative_risk_score": 25,
+            "evidence": [
+              {
+                "label": "Hostname",
+                "value": "\u0430pple.com"
+              },
+              {
+                "label": "Hostname (idna)",
+                "value": "xn--pple-43d.com"
+              },
+              {
+                "label": "Risk Delta",
+                "value": "+25"
+              },
+              {
+                "label": "Cumulative Risk",
+                "value": "25"
+              },
+              {
+                "label": "Signal",
+                "value": "At least one hostname character is outside ASCII."
+              }
+            ],
+            "explanation": "The domain includes Unicode characters, so visual lookalike checks are needed to rule out IDN spoofing.",
+            "family_explanation": "This web address uses unusual letters. Some scam links use this trick to look real.",
+            "module": "homoglyph",
+            "recommendations": [
+              "Pause before opening this link.",
+              "For important accounts, type the known website address yourself."
+            ],
+            "severity": "LOW",
+            "title": "Hostname contains non-ASCII characters"
+          }
+        ],
+        "redirect_trace": null
+      },
+      "family": {
+        "reasons": [
+          "This web address uses unusual letters. Some scam links use this trick to look real.",
+          "This link mixes different alphabets in one word to look like a known website.",
+          "Some letters in this link can be mistaken for normal English letters or numbers."
+        ],
+        "recommendations": [
+          "Pause before opening this link.",
+          "For important accounts, type the known website address yourself.",
+          "Do not sign in from this link."
+        ],
+        "risk_score": 94,
+        "severity": "CRITICAL",
+        "signal_confidence": "HIGH",
+        "summary": "High-risk warning: this link may impersonate a trusted site. Do not open it, and visit the real site by typing the address yourself."
+      },
+      "result": {
+        "analyzed_at": "<TIMESTAMP>",
+        "findings": [
+          {
+            "category": "HMG001_NON_ASCII_HOSTNAME",
+            "confidence": "MEDIUM",
+            "evidence": [
+              {
+                "label": "Hostname",
+                "value": "\u0430pple.com"
+              },
+              {
+                "label": "Hostname (idna)",
+                "value": "xn--pple-43d.com"
+              },
+              {
+                "label": "Risk Delta",
+                "value": "+25"
+              },
+              {
+                "label": "Cumulative Risk",
+                "value": "25"
+              },
+              {
+                "label": "Signal",
+                "value": "At least one hostname character is outside ASCII."
+              }
+            ],
+            "explanation": "The domain includes Unicode characters, so visual lookalike checks are needed to rule out IDN spoofing.",
+            "family_explanation": "This web address uses unusual letters. Some scam links use this trick to look real.",
+            "module": "homoglyph",
+            "recommendations": [
+              "Pause before opening this link.",
+              "For important accounts, type the known website address yourself."
+            ],
+            "risk_score": 25,
+            "severity": "LOW",
+            "title": "Hostname contains non-ASCII characters"
+          },
+          {
+            "category": "HMG003_MIXED_SCRIPT_HOSTNAME",
+            "confidence": "HIGH",
+            "evidence": [
+              {
+                "label": "Hostname",
+                "value": "\u0430pple.com"
+              },
+              {
+                "label": "Hostname (idna)",
+                "value": "xn--pple-43d.com"
+              },
+              {
+                "label": "Risk Delta",
+                "value": "+35"
+              },
+              {
+                "label": "Cumulative Risk",
+                "value": "60"
+              },
+              {
+                "label": "Label Scripts",
+                "value": "\u0430pple (Cyrillic, Latin)"
+              }
+            ],
+            "explanation": "One or more domain labels mix scripts (for example Latin + Cyrillic), which is a common homoglyph phishing pattern.",
+            "family_explanation": "This link mixes different alphabets in one word to look like a known website.",
+            "module": "homoglyph",
+            "recommendations": [
+              "Do not sign in from this link.",
+              "Verify the destination through a trusted app or bookmark."
+            ],
+            "risk_score": 60,
+            "severity": "MEDIUM",
+            "title": "Hostname label mixes writing systems"
+          },
+          {
+            "category": "HMG004_CONFUSABLE_CHARACTERS",
+            "confidence": "HIGH",
+            "evidence": [
+              {
+                "label": "Hostname",
+                "value": "\u0430pple.com"
+              },
+              {
+                "label": "Hostname (idna)",
+                "value": "xn--pple-43d.com"
+              },
+              {
+                "label": "Risk Delta",
+                "value": "+25"
+              },
+              {
+                "label": "Cumulative Risk",
+                "value": "85"
+              },
+              {
+                "label": "ASCII Lookalike",
+                "value": "apple.com"
+              },
+              {
+                "label": "Character Mapping",
+                "value": "\u0430 -> a"
+              }
+            ],
+            "explanation": "Unicode confusable analysis found hostname characters that can be read as different ASCII letters/numbers.",
+            "family_explanation": "Some letters in this link can be mistaken for normal English letters or numbers.",
+            "module": "homoglyph",
+            "recommendations": [
+              "Treat this as suspicious until confirmed by a trusted source.",
+              "Use official bookmarks for banking, shopping, and email logins."
+            ],
+            "risk_score": 85,
+            "severity": "CRITICAL",
+            "title": "Confusable hostname characters detected"
+          }
+        ],
+        "input": {
+          "content": "https://xn--pple-43d.com",
+          "input_type": "url",
+          "metadata": {
+            "allowlist_categories": [
+              "NONE"
+            ],
+            "allowlist_domains": [
+              "xn--pple-43d.com"
+            ],
+            "allowlist_findings": [
+              "HMG002_PUNYCODE_VISIBILITY"
+            ],
+            "network_enabled": false,
+            "network_max_hops": 5,
+            "network_timeout": 3.0
+          }
+        },
+        "overall_risk": 94,
+        "overall_severity": "CRITICAL",
+        "summary": "High-risk warning: this link may impersonate a trusted site. Do not open it, and visit the real site by typing the address yourself."
+      },
+      "subject": "https://xn--pple-43d.com"
+    },
+    "item_count": 1,
+    "mode": "single",
+    "schema_version": "2.0"
   }
 }

--- a/tests/fixtures/contracts/v1_v2_single_payloads.json
+++ b/tests/fixtures/contracts/v1_v2_single_payloads.json
@@ -1,27 +1,28 @@
 {
   "email_v1": {
+    "schema_version": "1.0",
     "flow": "email_check",
+    "mode": "single",
     "input_type": "email_headers",
+    "item_count": 1,
     "item": {
-      "family": {
-        "reasons": [
-          "The sender server did not pass a key email authenticity check (SPF)."
-        ],
-        "recommendations": [
-          "Avoid opening links or attachments until sender identity is verified.",
-          "Confirm the message through a separate trusted channel."
-        ],
-        "risk_score": 30,
-        "severity": "LOW",
-        "signal_confidence": "HIGH",
-        "summary": "A mild email authentication warning sign was found. Double-check sensitive requests before taking action."
-      },
+      "subject": "sample",
       "result": {
-        "analyzed_at": "<TIMESTAMP>",
+        "input": {
+          "input_type": "email_headers",
+          "content": "Authentication-Results: mx; spf=fail; dkim=pass; dmarc=pass",
+          "metadata": {}
+        },
         "findings": [
           {
+            "module": "email_auth",
             "category": "EML101_SPF_FAIL",
+            "severity": "LOW",
             "confidence": "HIGH",
+            "risk_score": 30,
+            "title": "SPF authentication failed",
+            "explanation": "SPF status indicates a failure or DNS/authentication error.",
+            "family_explanation": "The sender server did not pass a key email authenticity check (SPF).",
             "evidence": [
               {
                 "label": "SPF Status",
@@ -52,56 +53,56 @@
                 "value": "30"
               }
             ],
-            "explanation": "SPF status indicates a failure or DNS/authentication error.",
-            "family_explanation": "The sender server did not pass a key email authenticity check (SPF).",
-            "module": "email_auth",
             "recommendations": [
               "Avoid opening links or attachments until sender identity is verified.",
               "Confirm the message through a separate trusted channel."
-            ],
-            "risk_score": 30,
-            "severity": "LOW",
-            "title": "SPF authentication failed"
+            ]
           }
         ],
-        "input": {
-          "content": "Authentication-Results: mx; spf=fail; dkim=pass; dmarc=pass",
-          "input_type": "email_headers",
-          "metadata": {}
-        },
         "overall_risk": 30,
         "overall_severity": "LOW",
-        "summary": "A mild email authentication warning sign was found. Double-check sensitive requests before taking action."
+        "summary": "A mild email authentication warning sign was found. Double-check sensitive requests before taking action.",
+        "analyzed_at": "<TIMESTAMP>"
       },
-      "subject": "sample"
-    },
-    "item_count": 1,
-    "mode": "single",
-    "schema_version": "1.0"
+      "family": {
+        "risk_score": 30,
+        "severity": "LOW",
+        "summary": "A mild email authentication warning sign was found. Double-check sensitive requests before taking action.",
+        "signal_confidence": "HIGH",
+        "reasons": [
+          "The sender server did not pass a key email authenticity check (SPF)."
+        ],
+        "recommendations": [
+          "Avoid opening links or attachments until sender identity is verified.",
+          "Confirm the message through a separate trusted channel."
+        ]
+      }
+    }
   },
   "email_v2": {
+    "schema_version": "2.0",
     "flow": "analyze",
+    "mode": "single",
     "input_type": "email_headers",
+    "item_count": 1,
     "item": {
-      "family": {
-        "reasons": [
-          "The sender server did not pass a key email authenticity check (SPF)."
-        ],
-        "recommendations": [
-          "Avoid opening links or attachments until sender identity is verified.",
-          "Confirm the message through a separate trusted channel."
-        ],
-        "risk_score": 30,
-        "severity": "LOW",
-        "signal_confidence": "HIGH",
-        "summary": "A mild email authentication warning sign was found. Double-check sensitive requests before taking action."
-      },
+      "subject": "sample",
       "result": {
-        "analyzed_at": "<TIMESTAMP>",
+        "input": {
+          "input_type": "email_headers",
+          "content": "Authentication-Results: mx; spf=fail; dkim=pass; dmarc=pass",
+          "metadata": {}
+        },
         "findings": [
           {
+            "module": "email_auth",
             "category": "EML101_SPF_FAIL",
+            "severity": "LOW",
             "confidence": "HIGH",
+            "risk_score": 30,
+            "title": "SPF authentication failed",
+            "explanation": "SPF status indicates a failure or DNS/authentication error.",
+            "family_explanation": "The sender server did not pass a key email authenticity check (SPF).",
             "evidence": [
               {
                 "label": "SPF Status",
@@ -132,59 +133,69 @@
                 "value": "30"
               }
             ],
-            "explanation": "SPF status indicates a failure or DNS/authentication error.",
-            "family_explanation": "The sender server did not pass a key email authenticity check (SPF).",
-            "module": "email_auth",
             "recommendations": [
               "Avoid opening links or attachments until sender identity is verified.",
               "Confirm the message through a separate trusted channel."
-            ],
-            "risk_score": 30,
-            "severity": "LOW",
-            "title": "SPF authentication failed"
+            ]
           }
         ],
-        "input": {
-          "content": "Authentication-Results: mx; spf=fail; dkim=pass; dmarc=pass",
-          "input_type": "email_headers",
-          "metadata": {}
-        },
         "overall_risk": 30,
         "overall_severity": "LOW",
-        "summary": "A mild email authentication warning sign was found. Double-check sensitive requests before taking action."
+        "summary": "A mild email authentication warning sign was found. Double-check sensitive requests before taking action.",
+        "analyzed_at": "<TIMESTAMP>"
       },
-      "subject": "sample"
-    },
-    "item_count": 1,
-    "mode": "single",
-    "schema_version": "2.0"
-  },
-  "url_v1": {
-    "flow": "url_check",
-    "input_type": "url",
-    "item": {
       "family": {
+        "risk_score": 30,
+        "severity": "LOW",
+        "summary": "A mild email authentication warning sign was found. Double-check sensitive requests before taking action.",
+        "signal_confidence": "HIGH",
         "reasons": [
-          "This web address uses unusual letters. Some scam links use this trick to look real.",
-          "This link mixes different alphabets in one word to look like a known website.",
-          "Some letters in this link can be mistaken for normal English letters or numbers."
+          "The sender server did not pass a key email authenticity check (SPF)."
         ],
         "recommendations": [
-          "Pause before opening this link.",
-          "For important accounts, type the known website address yourself.",
-          "Do not sign in from this link."
-        ],
-        "risk_score": 94,
-        "severity": "CRITICAL",
-        "signal_confidence": "HIGH",
-        "summary": "High-risk warning: this link may impersonate a trusted site. Do not open it, and visit the real site by typing the address yourself."
-      },
+          "Avoid opening links or attachments until sender identity is verified.",
+          "Confirm the message through a separate trusted channel."
+        ]
+      }
+    }
+  },
+  "url_v1": {
+    "schema_version": "1.0",
+    "flow": "url_check",
+    "mode": "single",
+    "input_type": "url",
+    "item_count": 1,
+    "item": {
+      "subject": "https://xn--pple-43d.com",
       "result": {
-        "analyzed_at": "<TIMESTAMP>",
+        "input": {
+          "input_type": "url",
+          "content": "https://xn--pple-43d.com",
+          "metadata": {
+            "allowlist_domains": [
+              "xn--pple-43d.com"
+            ],
+            "allowlist_categories": [
+              "NONE"
+            ],
+            "allowlist_findings": [
+              "HMG002_PUNYCODE_VISIBILITY"
+            ],
+            "network_enabled": false,
+            "network_max_hops": 5,
+            "network_timeout": 3.0
+          }
+        },
         "findings": [
           {
+            "module": "homoglyph",
             "category": "HMG001_NON_ASCII_HOSTNAME",
+            "severity": "LOW",
             "confidence": "MEDIUM",
+            "risk_score": 25,
+            "title": "Hostname contains non-ASCII characters",
+            "explanation": "The domain includes Unicode characters, so visual lookalike checks are needed to rule out IDN spoofing.",
+            "family_explanation": "This web address uses unusual letters. Some scam links use this trick to look real.",
             "evidence": [
               {
                 "label": "Hostname",
@@ -207,20 +218,20 @@
                 "value": "At least one hostname character is outside ASCII."
               }
             ],
-            "explanation": "The domain includes Unicode characters, so visual lookalike checks are needed to rule out IDN spoofing.",
-            "family_explanation": "This web address uses unusual letters. Some scam links use this trick to look real.",
-            "module": "homoglyph",
             "recommendations": [
               "Pause before opening this link.",
               "For important accounts, type the known website address yourself."
-            ],
-            "risk_score": 25,
-            "severity": "LOW",
-            "title": "Hostname contains non-ASCII characters"
+            ]
           },
           {
+            "module": "homoglyph",
             "category": "HMG003_MIXED_SCRIPT_HOSTNAME",
+            "severity": "MEDIUM",
             "confidence": "HIGH",
+            "risk_score": 60,
+            "title": "Hostname label mixes writing systems",
+            "explanation": "One or more domain labels mix scripts (for example Latin + Cyrillic), which is a common homoglyph phishing pattern.",
+            "family_explanation": "This link mixes different alphabets in one word to look like a known website.",
             "evidence": [
               {
                 "label": "Hostname",
@@ -243,20 +254,20 @@
                 "value": "\u0430pple (Cyrillic, Latin)"
               }
             ],
-            "explanation": "One or more domain labels mix scripts (for example Latin + Cyrillic), which is a common homoglyph phishing pattern.",
-            "family_explanation": "This link mixes different alphabets in one word to look like a known website.",
-            "module": "homoglyph",
             "recommendations": [
               "Do not sign in from this link.",
               "Verify the destination through a trusted app or bookmark."
-            ],
-            "risk_score": 60,
-            "severity": "MEDIUM",
-            "title": "Hostname label mixes writing systems"
+            ]
           },
           {
+            "module": "homoglyph",
             "category": "HMG004_CONFUSABLE_CHARACTERS",
+            "severity": "CRITICAL",
             "confidence": "HIGH",
+            "risk_score": 85,
+            "title": "Confusable hostname characters detected",
+            "explanation": "Unicode confusable analysis found hostname characters that can be read as different ASCII letters/numbers.",
+            "family_explanation": "Some letters in this link can be mistaken for normal English letters or numbers.",
             "evidence": [
               {
                 "label": "Hostname",
@@ -283,27 +294,53 @@
                 "value": "\u0430 -> a"
               }
             ],
-            "explanation": "Unicode confusable analysis found hostname characters that can be read as different ASCII letters/numbers.",
-            "family_explanation": "Some letters in this link can be mistaken for normal English letters or numbers.",
-            "module": "homoglyph",
             "recommendations": [
               "Treat this as suspicious until confirmed by a trusted source.",
               "Use official bookmarks for banking, shopping, and email logins."
-            ],
-            "risk_score": 85,
-            "severity": "CRITICAL",
-            "title": "Confusable hostname characters detected"
+            ]
           }
         ],
+        "overall_risk": 94,
+        "overall_severity": "CRITICAL",
+        "summary": "High-risk warning: this link may impersonate a trusted site. Do not open it, and visit the real site by typing the address yourself.",
+        "analyzed_at": "<TIMESTAMP>"
+      },
+      "family": {
+        "risk_score": 94,
+        "severity": "CRITICAL",
+        "summary": "High-risk warning: this link may impersonate a trusted site. Do not open it, and visit the real site by typing the address yourself.",
+        "signal_confidence": "HIGH",
+        "reasons": [
+          "This web address uses unusual letters. Some scam links use this trick to look real.",
+          "This link mixes different alphabets in one word to look like a known website.",
+          "Some letters in this link can be mistaken for normal English letters or numbers."
+        ],
+        "recommendations": [
+          "Pause before opening this link.",
+          "For important accounts, type the known website address yourself.",
+          "Do not sign in from this link."
+        ]
+      }
+    }
+  },
+  "url_v2": {
+    "schema_version": "2.0",
+    "flow": "analyze",
+    "mode": "single",
+    "input_type": "url",
+    "item_count": 1,
+    "item": {
+      "subject": "https://xn--pple-43d.com",
+      "result": {
         "input": {
-          "content": "https://xn--pple-43d.com",
           "input_type": "url",
+          "content": "https://xn--pple-43d.com",
           "metadata": {
-            "allowlist_categories": [
-              "NONE"
-            ],
             "allowlist_domains": [
               "xn--pple-43d.com"
+            ],
+            "allowlist_categories": [
+              "NONE"
             ],
             "allowlist_findings": [
               "HMG002_PUNYCODE_VISIBILITY"
@@ -313,47 +350,177 @@
             "network_timeout": 3.0
           }
         },
+        "findings": [
+          {
+            "module": "homoglyph",
+            "category": "HMG001_NON_ASCII_HOSTNAME",
+            "severity": "LOW",
+            "confidence": "MEDIUM",
+            "risk_score": 25,
+            "title": "Hostname contains non-ASCII characters",
+            "explanation": "The domain includes Unicode characters, so visual lookalike checks are needed to rule out IDN spoofing.",
+            "family_explanation": "This web address uses unusual letters. Some scam links use this trick to look real.",
+            "evidence": [
+              {
+                "label": "Hostname",
+                "value": "\u0430pple.com"
+              },
+              {
+                "label": "Hostname (idna)",
+                "value": "xn--pple-43d.com"
+              },
+              {
+                "label": "Risk Delta",
+                "value": "+25"
+              },
+              {
+                "label": "Cumulative Risk",
+                "value": "25"
+              },
+              {
+                "label": "Signal",
+                "value": "At least one hostname character is outside ASCII."
+              }
+            ],
+            "recommendations": [
+              "Pause before opening this link.",
+              "For important accounts, type the known website address yourself."
+            ]
+          },
+          {
+            "module": "homoglyph",
+            "category": "HMG003_MIXED_SCRIPT_HOSTNAME",
+            "severity": "MEDIUM",
+            "confidence": "HIGH",
+            "risk_score": 60,
+            "title": "Hostname label mixes writing systems",
+            "explanation": "One or more domain labels mix scripts (for example Latin + Cyrillic), which is a common homoglyph phishing pattern.",
+            "family_explanation": "This link mixes different alphabets in one word to look like a known website.",
+            "evidence": [
+              {
+                "label": "Hostname",
+                "value": "\u0430pple.com"
+              },
+              {
+                "label": "Hostname (idna)",
+                "value": "xn--pple-43d.com"
+              },
+              {
+                "label": "Risk Delta",
+                "value": "+35"
+              },
+              {
+                "label": "Cumulative Risk",
+                "value": "60"
+              },
+              {
+                "label": "Label Scripts",
+                "value": "\u0430pple (Cyrillic, Latin)"
+              }
+            ],
+            "recommendations": [
+              "Do not sign in from this link.",
+              "Verify the destination through a trusted app or bookmark."
+            ]
+          },
+          {
+            "module": "homoglyph",
+            "category": "HMG004_CONFUSABLE_CHARACTERS",
+            "severity": "CRITICAL",
+            "confidence": "HIGH",
+            "risk_score": 85,
+            "title": "Confusable hostname characters detected",
+            "explanation": "Unicode confusable analysis found hostname characters that can be read as different ASCII letters/numbers.",
+            "family_explanation": "Some letters in this link can be mistaken for normal English letters or numbers.",
+            "evidence": [
+              {
+                "label": "Hostname",
+                "value": "\u0430pple.com"
+              },
+              {
+                "label": "Hostname (idna)",
+                "value": "xn--pple-43d.com"
+              },
+              {
+                "label": "Risk Delta",
+                "value": "+25"
+              },
+              {
+                "label": "Cumulative Risk",
+                "value": "85"
+              },
+              {
+                "label": "ASCII Lookalike",
+                "value": "apple.com"
+              },
+              {
+                "label": "Character Mapping",
+                "value": "\u0430 -> a"
+              }
+            ],
+            "recommendations": [
+              "Treat this as suspicious until confirmed by a trusted source.",
+              "Use official bookmarks for banking, shopping, and email logins."
+            ]
+          }
+        ],
         "overall_risk": 94,
         "overall_severity": "CRITICAL",
-        "summary": "High-risk warning: this link may impersonate a trusted site. Do not open it, and visit the real site by typing the address yourself."
+        "summary": "High-risk warning: this link may impersonate a trusted site. Do not open it, and visit the real site by typing the address yourself.",
+        "analyzed_at": "<TIMESTAMP>"
       },
-      "subject": "https://xn--pple-43d.com"
-    },
-    "item_count": 1,
-    "mode": "single",
-    "schema_version": "1.0"
-  },
-  "url_v2": {
-    "flow": "analyze",
-    "input_type": "url",
-    "item": {
+      "family": {
+        "risk_score": 94,
+        "severity": "CRITICAL",
+        "summary": "High-risk warning: this link may impersonate a trusted site. Do not open it, and visit the real site by typing the address yourself.",
+        "signal_confidence": "HIGH",
+        "reasons": [
+          "This web address uses unusual letters. Some scam links use this trick to look real.",
+          "This link mixes different alphabets in one word to look like a known website.",
+          "Some letters in this link can be mistaken for normal English letters or numbers."
+        ],
+        "recommendations": [
+          "Pause before opening this link.",
+          "For important accounts, type the known website address yourself.",
+          "Do not sign in from this link."
+        ]
+      },
       "analyst": {
         "domain_anatomy": {
-          "canonical_hostname": "xn--pple-43d.com",
-          "canonical_registrable_domain": "xn--pple-43d.com",
+          "submitted_url": "https://xn--pple-43d.com",
           "canonical_url": "https://xn--pple-43d.com/",
           "hostname": "xn--pple-43d.com",
-          "idna_ascii_hostname": "xn--pple-43d.com",
-          "idna_unicode_hostname": "\u0430pple.com",
-          "ip_literal": null,
-          "ipv6_mapped_ipv4": null,
-          "is_ip_literal": false,
-          "normalization_notes": [],
-          "obfuscated_ipv4": null,
-          "obfuscated_ipv4_notes": [],
+          "canonical_hostname": "xn--pple-43d.com",
           "registrable_domain": "xn--pple-43d.com",
+          "canonical_registrable_domain": "xn--pple-43d.com",
+          "subdomain_labels": [],
           "registrable_labels": [
             "xn--pple-43d",
             "com"
           ],
-          "subdomain_labels": [],
-          "submitted_url": "https://xn--pple-43d.com"
+          "idna_ascii_hostname": "xn--pple-43d.com",
+          "idna_unicode_hostname": "\u0430pple.com",
+          "is_ip_literal": false,
+          "ip_literal": null,
+          "obfuscated_ipv4": null,
+          "obfuscated_ipv4_notes": [],
+          "ipv6_mapped_ipv4": null,
+          "normalization_notes": []
         },
         "evidence_rows": [
           {
+            "module": "homoglyph",
             "category": "HMG004_CONFUSABLE_CHARACTERS",
+            "severity": "CRITICAL",
             "confidence": "HIGH",
             "cumulative_risk_score": 85,
+            "title": "Confusable hostname characters detected",
+            "explanation": "Unicode confusable analysis found hostname characters that can be read as different ASCII letters/numbers.",
+            "family_explanation": "Some letters in this link can be mistaken for normal English letters or numbers.",
+            "recommendations": [
+              "Treat this as suspicious until confirmed by a trusted source.",
+              "Use official bookmarks for banking, shopping, and email logins."
+            ],
             "evidence": [
               {
                 "label": "Hostname",
@@ -379,21 +546,21 @@
                 "label": "Character Mapping",
                 "value": "\u0430 -> a"
               }
-            ],
-            "explanation": "Unicode confusable analysis found hostname characters that can be read as different ASCII letters/numbers.",
-            "family_explanation": "Some letters in this link can be mistaken for normal English letters or numbers.",
-            "module": "homoglyph",
-            "recommendations": [
-              "Treat this as suspicious until confirmed by a trusted source.",
-              "Use official bookmarks for banking, shopping, and email logins."
-            ],
-            "severity": "CRITICAL",
-            "title": "Confusable hostname characters detected"
+            ]
           },
           {
+            "module": "homoglyph",
             "category": "HMG003_MIXED_SCRIPT_HOSTNAME",
+            "severity": "MEDIUM",
             "confidence": "HIGH",
             "cumulative_risk_score": 60,
+            "title": "Hostname label mixes writing systems",
+            "explanation": "One or more domain labels mix scripts (for example Latin + Cyrillic), which is a common homoglyph phishing pattern.",
+            "family_explanation": "This link mixes different alphabets in one word to look like a known website.",
+            "recommendations": [
+              "Do not sign in from this link.",
+              "Verify the destination through a trusted app or bookmark."
+            ],
             "evidence": [
               {
                 "label": "Hostname",
@@ -415,21 +582,21 @@
                 "label": "Label Scripts",
                 "value": "\u0430pple (Cyrillic, Latin)"
               }
-            ],
-            "explanation": "One or more domain labels mix scripts (for example Latin + Cyrillic), which is a common homoglyph phishing pattern.",
-            "family_explanation": "This link mixes different alphabets in one word to look like a known website.",
-            "module": "homoglyph",
-            "recommendations": [
-              "Do not sign in from this link.",
-              "Verify the destination through a trusted app or bookmark."
-            ],
-            "severity": "MEDIUM",
-            "title": "Hostname label mixes writing systems"
+            ]
           },
           {
+            "module": "homoglyph",
             "category": "HMG001_NON_ASCII_HOSTNAME",
+            "severity": "LOW",
             "confidence": "MEDIUM",
             "cumulative_risk_score": 25,
+            "title": "Hostname contains non-ASCII characters",
+            "explanation": "The domain includes Unicode characters, so visual lookalike checks are needed to rule out IDN spoofing.",
+            "family_explanation": "This web address uses unusual letters. Some scam links use this trick to look real.",
+            "recommendations": [
+              "Pause before opening this link.",
+              "For important accounts, type the known website address yourself."
+            ],
             "evidence": [
               {
                 "label": "Hostname",
@@ -451,178 +618,37 @@
                 "label": "Signal",
                 "value": "At least one hostname character is outside ASCII."
               }
-            ],
-            "explanation": "The domain includes Unicode characters, so visual lookalike checks are needed to rule out IDN spoofing.",
-            "family_explanation": "This web address uses unusual letters. Some scam links use this trick to look real.",
-            "module": "homoglyph",
-            "recommendations": [
-              "Pause before opening this link.",
-              "For important accounts, type the known website address yourself."
-            ],
-            "severity": "LOW",
-            "title": "Hostname contains non-ASCII characters"
+            ]
           }
         ],
-        "redirect_trace": null
-      },
-      "family": {
-        "reasons": [
-          "This web address uses unusual letters. Some scam links use this trick to look real.",
-          "This link mixes different alphabets in one word to look like a known website.",
-          "Some letters in this link can be mistaken for normal English letters or numbers."
-        ],
-        "recommendations": [
-          "Pause before opening this link.",
-          "For important accounts, type the known website address yourself.",
-          "Do not sign in from this link."
-        ],
-        "risk_score": 94,
-        "severity": "CRITICAL",
-        "signal_confidence": "HIGH",
-        "summary": "High-risk warning: this link may impersonate a trusted site. Do not open it, and visit the real site by typing the address yourself."
-      },
-      "result": {
-        "analyzed_at": "<TIMESTAMP>",
-        "findings": [
-          {
-            "category": "HMG001_NON_ASCII_HOSTNAME",
-            "confidence": "MEDIUM",
-            "evidence": [
-              {
-                "label": "Hostname",
-                "value": "\u0430pple.com"
-              },
-              {
-                "label": "Hostname (idna)",
-                "value": "xn--pple-43d.com"
-              },
-              {
-                "label": "Risk Delta",
-                "value": "+25"
-              },
-              {
-                "label": "Cumulative Risk",
-                "value": "25"
-              },
-              {
-                "label": "Signal",
-                "value": "At least one hostname character is outside ASCII."
-              }
-            ],
-            "explanation": "The domain includes Unicode characters, so visual lookalike checks are needed to rule out IDN spoofing.",
-            "family_explanation": "This web address uses unusual letters. Some scam links use this trick to look real.",
-            "module": "homoglyph",
-            "recommendations": [
-              "Pause before opening this link.",
-              "For important accounts, type the known website address yourself."
-            ],
-            "risk_score": 25,
-            "severity": "LOW",
-            "title": "Hostname contains non-ASCII characters"
-          },
-          {
-            "category": "HMG003_MIXED_SCRIPT_HOSTNAME",
-            "confidence": "HIGH",
-            "evidence": [
-              {
-                "label": "Hostname",
-                "value": "\u0430pple.com"
-              },
-              {
-                "label": "Hostname (idna)",
-                "value": "xn--pple-43d.com"
-              },
-              {
-                "label": "Risk Delta",
-                "value": "+35"
-              },
-              {
-                "label": "Cumulative Risk",
-                "value": "60"
-              },
-              {
-                "label": "Label Scripts",
-                "value": "\u0430pple (Cyrillic, Latin)"
-              }
-            ],
-            "explanation": "One or more domain labels mix scripts (for example Latin + Cyrillic), which is a common homoglyph phishing pattern.",
-            "family_explanation": "This link mixes different alphabets in one word to look like a known website.",
-            "module": "homoglyph",
-            "recommendations": [
-              "Do not sign in from this link.",
-              "Verify the destination through a trusted app or bookmark."
-            ],
-            "risk_score": 60,
-            "severity": "MEDIUM",
-            "title": "Hostname label mixes writing systems"
-          },
-          {
-            "category": "HMG004_CONFUSABLE_CHARACTERS",
-            "confidence": "HIGH",
-            "evidence": [
-              {
-                "label": "Hostname",
-                "value": "\u0430pple.com"
-              },
-              {
-                "label": "Hostname (idna)",
-                "value": "xn--pple-43d.com"
-              },
-              {
-                "label": "Risk Delta",
-                "value": "+25"
-              },
-              {
-                "label": "Cumulative Risk",
-                "value": "85"
-              },
-              {
-                "label": "ASCII Lookalike",
-                "value": "apple.com"
-              },
-              {
-                "label": "Character Mapping",
-                "value": "\u0430 -> a"
-              }
-            ],
-            "explanation": "Unicode confusable analysis found hostname characters that can be read as different ASCII letters/numbers.",
-            "family_explanation": "Some letters in this link can be mistaken for normal English letters or numbers.",
-            "module": "homoglyph",
-            "recommendations": [
-              "Treat this as suspicious until confirmed by a trusted source.",
-              "Use official bookmarks for banking, shopping, and email logins."
-            ],
-            "risk_score": 85,
-            "severity": "CRITICAL",
-            "title": "Confusable hostname characters detected"
-          }
-        ],
-        "input": {
-          "content": "https://xn--pple-43d.com",
-          "input_type": "url",
-          "metadata": {
-            "allowlist_categories": [
-              "NONE"
-            ],
-            "allowlist_domains": [
-              "xn--pple-43d.com"
-            ],
-            "allowlist_findings": [
-              "HMG002_PUNYCODE_VISIBILITY"
-            ],
-            "network_enabled": false,
-            "network_max_hops": 5,
-            "network_timeout": 3.0
-          }
-        },
-        "overall_risk": 94,
-        "overall_severity": "CRITICAL",
-        "summary": "High-risk warning: this link may impersonate a trusted site. Do not open it, and visit the real site by typing the address yourself."
-      },
-      "subject": "https://xn--pple-43d.com"
-    },
-    "item_count": 1,
-    "mode": "single",
-    "schema_version": "2.0"
+        "redirect_trace": null,
+        "suppression_trace": {
+          "hostname": "xn--pple-43d.com",
+          "configured_allowlist_domains": [
+            "xn--pple-43d.com",
+            "\u0430pple.com"
+          ],
+          "configured_allowlist_categories": [],
+          "configured_allowlist_findings": [
+            "HMG002_PUNYCODE_VISIBILITY"
+          ],
+          "matched_allowlist_domains": [
+            "xn--pple-43d.com"
+          ],
+          "suppressed_count": 1,
+          "suppressed_rows": [
+            {
+              "module": "homoglyph",
+              "category": "HMG002_PUNYCODE_VISIBILITY",
+              "hostname": "xn--pple-43d.com",
+              "matched_allowlist_domain": "xn--pple-43d.com",
+              "suppression_scope": "finding",
+              "matched_rule": "HMG002_PUNYCODE_VISIBILITY",
+              "reason": "Suppressed because the hostname matched an allowlist domain and finding token HMG002_PUNYCODE_VISIBILITY was enabled."
+            }
+          ]
+        }
+      }
+    }
   }
 }

--- a/tests/fixtures/contracts/v1_v2_single_payloads.json
+++ b/tests/fixtures/contracts/v1_v2_single_payloads.json
@@ -511,9 +511,13 @@
           {
             "module": "homoglyph",
             "category": "HMG004_CONFUSABLE_CHARACTERS",
+            "finding_key": "homoglyph:HMG004_CONFUSABLE_CHARACTERS",
+            "compare_key": "homoglyph:HMG004_CONFUSABLE_CHARACTERS",
+            "sort_index": 0,
             "severity": "CRITICAL",
             "confidence": "HIGH",
             "cumulative_risk_score": 85,
+            "risk_delta": 25,
             "title": "Confusable hostname characters detected",
             "explanation": "Unicode confusable analysis found hostname characters that can be read as different ASCII letters/numbers.",
             "family_explanation": "Some letters in this link can be mistaken for normal English letters or numbers.",
@@ -523,37 +527,55 @@
             ],
             "evidence": [
               {
+                "key": "hostname",
                 "label": "Hostname",
                 "value": "\u0430pple.com"
               },
               {
+                "key": "hostname_idna",
                 "label": "Hostname (idna)",
                 "value": "xn--pple-43d.com"
               },
               {
+                "key": "risk_delta",
                 "label": "Risk Delta",
                 "value": "+25"
               },
               {
+                "key": "cumulative_risk",
                 "label": "Cumulative Risk",
                 "value": "85"
               },
               {
+                "key": "ascii_lookalike",
                 "label": "ASCII Lookalike",
                 "value": "apple.com"
               },
               {
+                "key": "character_mapping",
                 "label": "Character Mapping",
                 "value": "\u0430 -> a"
               }
-            ]
+            ],
+            "evidence_map": {
+              "hostname": "\u0430pple.com",
+              "hostname_idna": "xn--pple-43d.com",
+              "risk_delta": "+25",
+              "cumulative_risk": "85",
+              "ascii_lookalike": "apple.com",
+              "character_mapping": "\u0430 -> a"
+            }
           },
           {
             "module": "homoglyph",
             "category": "HMG003_MIXED_SCRIPT_HOSTNAME",
+            "finding_key": "homoglyph:HMG003_MIXED_SCRIPT_HOSTNAME",
+            "compare_key": "homoglyph:HMG003_MIXED_SCRIPT_HOSTNAME",
+            "sort_index": 1,
             "severity": "MEDIUM",
             "confidence": "HIGH",
             "cumulative_risk_score": 60,
+            "risk_delta": 35,
             "title": "Hostname label mixes writing systems",
             "explanation": "One or more domain labels mix scripts (for example Latin + Cyrillic), which is a common homoglyph phishing pattern.",
             "family_explanation": "This link mixes different alphabets in one word to look like a known website.",
@@ -563,33 +585,49 @@
             ],
             "evidence": [
               {
+                "key": "hostname",
                 "label": "Hostname",
                 "value": "\u0430pple.com"
               },
               {
+                "key": "hostname_idna",
                 "label": "Hostname (idna)",
                 "value": "xn--pple-43d.com"
               },
               {
+                "key": "risk_delta",
                 "label": "Risk Delta",
                 "value": "+35"
               },
               {
+                "key": "cumulative_risk",
                 "label": "Cumulative Risk",
                 "value": "60"
               },
               {
+                "key": "label_scripts",
                 "label": "Label Scripts",
                 "value": "\u0430pple (Cyrillic, Latin)"
               }
-            ]
+            ],
+            "evidence_map": {
+              "hostname": "\u0430pple.com",
+              "hostname_idna": "xn--pple-43d.com",
+              "risk_delta": "+35",
+              "cumulative_risk": "60",
+              "label_scripts": "\u0430pple (Cyrillic, Latin)"
+            }
           },
           {
             "module": "homoglyph",
             "category": "HMG001_NON_ASCII_HOSTNAME",
+            "finding_key": "homoglyph:HMG001_NON_ASCII_HOSTNAME",
+            "compare_key": "homoglyph:HMG001_NON_ASCII_HOSTNAME",
+            "sort_index": 2,
             "severity": "LOW",
             "confidence": "MEDIUM",
             "cumulative_risk_score": 25,
+            "risk_delta": 25,
             "title": "Hostname contains non-ASCII characters",
             "explanation": "The domain includes Unicode characters, so visual lookalike checks are needed to rule out IDN spoofing.",
             "family_explanation": "This web address uses unusual letters. Some scam links use this trick to look real.",
@@ -599,26 +637,38 @@
             ],
             "evidence": [
               {
+                "key": "hostname",
                 "label": "Hostname",
                 "value": "\u0430pple.com"
               },
               {
+                "key": "hostname_idna",
                 "label": "Hostname (idna)",
                 "value": "xn--pple-43d.com"
               },
               {
+                "key": "risk_delta",
                 "label": "Risk Delta",
                 "value": "+25"
               },
               {
+                "key": "cumulative_risk",
                 "label": "Cumulative Risk",
                 "value": "25"
               },
               {
+                "key": "signal",
                 "label": "Signal",
                 "value": "At least one hostname character is outside ASCII."
               }
-            ]
+            ],
+            "evidence_map": {
+              "hostname": "\u0430pple.com",
+              "hostname_idna": "xn--pple-43d.com",
+              "risk_delta": "+25",
+              "cumulative_risk": "25",
+              "signal": "At least one hostname character is outside ASCII."
+            }
           }
         ],
         "redirect_trace": null,
@@ -640,6 +690,9 @@
             {
               "module": "homoglyph",
               "category": "HMG002_PUNYCODE_VISIBILITY",
+              "finding_key": "homoglyph:HMG002_PUNYCODE_VISIBILITY",
+              "compare_key": "homoglyph:HMG002_PUNYCODE_VISIBILITY:finding:hmg002_punycode_visibility",
+              "sort_index": 0,
               "hostname": "xn--pple-43d.com",
               "matched_allowlist_domain": "xn--pple-43d.com",
               "suppression_scope": "finding",

--- a/tests/formatters/test_structured.py
+++ b/tests/formatters/test_structured.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 
-from lsh.core.models import AnalysisInput, AnalysisResult, Confidence, Finding, Severity
+from lsh.application import analyze_url
+from lsh.core.models import AnalysisInput, AnalysisResult, Confidence, Evidence, Finding, Severity
 from lsh.formatters.structured import (
     build_multi_result_payload,
     build_qr_scan_payload,
@@ -12,30 +13,28 @@ from lsh.formatters.structured import (
 )
 
 
-def _result(subject: str, risk: int = 0) -> AnalysisResult:
-    finding_list: list[Finding]
-    if risk > 0:
-        finding_list = [
-            Finding(
-                module="test",
-                category="TST001",
-                severity=Severity.INFO,
-                confidence=Confidence.MEDIUM,
-                risk_score=risk,
-                title="Test finding",
-                explanation="Test explanation.",
-                family_explanation="Test family explanation.",
-                recommendations=["Test recommendation."],
-            )
-        ]
-    else:
-        finding_list = []
+def _finding(risk: int, *, module: str = "test", category: str = "TST001") -> Finding:
+    return Finding(
+        module=module,
+        category=category,
+        severity=Severity.INFO,
+        confidence=Confidence.MEDIUM,
+        risk_score=risk,
+        title="Test finding",
+        explanation="Test explanation.",
+        family_explanation="Test family explanation.",
+        recommendations=["Test recommendation."],
+    )
 
+
+def _result(subject: str, risk: int = 0, findings: list[Finding] | None = None) -> AnalysisResult:
+    finding_list = findings if findings is not None else ([_finding(risk)] if risk > 0 else [])
+    overall_risk = finding_list[-1].risk_score if finding_list else risk
     return AnalysisResult(
         input=AnalysisInput(input_type="url", content=subject),
         findings=finding_list,
-        overall_risk=risk,
-        overall_severity=Severity.INFO if risk == 0 else Severity.MEDIUM,
+        overall_risk=overall_risk,
+        overall_severity=Severity.INFO if overall_risk == 0 else Severity.MEDIUM,
         summary="Summary.",
         analyzed_at=datetime.now(UTC),
     )
@@ -58,6 +57,7 @@ def test_single_payload_shape_is_stable() -> None:
     assert item["subject"] == "https://example.com"
     assert "result" in item
     assert "family" in item
+    assert "analyst" not in item
 
 
 def test_multi_payload_shape_is_stable() -> None:
@@ -87,6 +87,108 @@ def test_single_payload_can_override_schema_version() -> None:
         schema_version="2.0",
     )
     assert payload["schema_version"] == "2.0"
+    item = payload["item"]
+    assert isinstance(item, dict)
+    assert "analyst" in item
+
+
+def test_v2_url_payload_includes_analyst_projection() -> None:
+    result = analyze_url("https://xn--pple-43d.com")
+    payload = build_single_result_payload(
+        flow="analyze",
+        input_type="url",
+        subject="https://xn--pple-43d.com",
+        result=result,
+        include_family=True,
+        schema_version="2.0",
+    )
+
+    item = payload["item"]
+    assert isinstance(item, dict)
+    analyst = item["analyst"]
+    assert isinstance(analyst, dict)
+    domain_anatomy = analyst["domain_anatomy"]
+    evidence_rows = analyst["evidence_rows"]
+    assert isinstance(domain_anatomy, dict)
+    assert domain_anatomy["submitted_url"] == "https://xn--pple-43d.com"
+    assert domain_anatomy["canonical_url"] == "https://xn--pple-43d.com/"
+    assert domain_anatomy["hostname"] == "xn--pple-43d.com"
+    assert domain_anatomy["registrable_domain"] == "xn--pple-43d.com"
+    assert isinstance(evidence_rows, list)
+    assert evidence_rows
+    assert evidence_rows[0]["cumulative_risk_score"] >= evidence_rows[-1]["cumulative_risk_score"]
+
+
+def test_v2_url_payload_builds_redirect_trace_from_findings() -> None:
+    redirect_findings = [
+        Finding(
+            module="redirect",
+            category="RED001_REDIRECT_CHAIN_PRESENT",
+            severity=Severity.INFO,
+            confidence=Confidence.LOW,
+            risk_score=15,
+            title="URL redirects before reaching a final destination",
+            explanation="Redirect chain present.",
+            family_explanation="This link bounces through another address before it finishes loading.",
+            evidence=[
+                Evidence(label="Redirect Hops", value="2"),
+                Evidence(label="Chain", value="https://start.example -> https://mid.example -> https://final.example"),
+                Evidence(label="Start URL", value="https://start.example"),
+                Evidence(label="Final URL", value="https://final.example"),
+            ],
+            recommendations=["Check the final destination before signing in or entering payment details."],
+        ),
+        Finding(
+            module="redirect",
+            category="RED002_CROSS_DOMAIN_REDIRECT",
+            severity=Severity.INFO,
+            confidence=Confidence.MEDIUM,
+            risk_score=40,
+            title="Redirect chain changes registrable domain",
+            explanation="Cross-domain jumps increase destination uncertainty.",
+            family_explanation="This link starts on one site name and ends on a different site name.",
+            evidence=[
+                Evidence(label="Redirect Hops", value="2"),
+                Evidence(label="Chain", value="https://start.example -> https://mid.example -> https://final.example"),
+                Evidence(label="Domain Path", value="start.example -> mid.example -> final.example"),
+            ],
+            recommendations=["Verify that the final site name is expected and trusted."],
+        ),
+        Finding(
+            module="redirect",
+            category="RED005_REQUEST_TIMEOUT",
+            severity=Severity.INFO,
+            confidence=Confidence.MEDIUM,
+            risk_score=70,
+            title="Redirect check timed out",
+            explanation="Network redirect analysis timed out before completion.",
+            family_explanation="This link took too long to resolve, so checks are incomplete.",
+            evidence=[
+                Evidence(label="Redirect Hops", value="2"),
+                Evidence(label="Chain", value="https://start.example -> https://mid.example -> https://final.example"),
+            ],
+            recommendations=["Treat unresolved links cautiously and verify before opening."],
+        ),
+    ]
+    payload = build_single_result_payload(
+        flow="analyze",
+        input_type="url",
+        subject="https://start.example",
+        result=_result("https://start.example", findings=redirect_findings),
+        schema_version="2.0",
+    )
+
+    item = payload["item"]
+    assert isinstance(item, dict)
+    analyst = item["analyst"]
+    assert isinstance(analyst, dict)
+    redirect_trace = analyst["redirect_trace"]
+    assert isinstance(redirect_trace, dict)
+    assert redirect_trace["start_url"] == "https://start.example"
+    assert redirect_trace["final_url"] == "https://final.example"
+    assert redirect_trace["hop_count"] == 2
+    assert redirect_trace["crosses_registrable_domain"] is True
+    assert redirect_trace["timed_out"] is True
 
 
 def test_multi_payload_can_override_schema_version() -> None:
@@ -170,3 +272,4 @@ def test_qr_payload_can_disable_legacy_keys_for_multi_mode() -> None:
     assert "items" in payload
     assert "image_path" not in payload
     assert "results" not in payload
+

--- a/tests/formatters/test_structured.py
+++ b/tests/formatters/test_structured.py
@@ -117,6 +117,13 @@ def test_v2_url_payload_includes_analyst_projection() -> None:
     assert isinstance(evidence_rows, list)
     assert evidence_rows
     assert evidence_rows[0]["cumulative_risk_score"] >= evidence_rows[-1]["cumulative_risk_score"]
+    first_row = evidence_rows[0]
+    assert first_row["finding_key"] == "homoglyph:HMG004_CONFUSABLE_CHARACTERS"
+    assert first_row["compare_key"] == "homoglyph:HMG004_CONFUSABLE_CHARACTERS"
+    assert first_row["sort_index"] == 0
+    assert first_row["risk_delta"] == 25
+    assert first_row["evidence"][0]["key"] == "hostname"
+    assert first_row["evidence_map"]["hostname"] == "\u0430pple.com"
 
 
 def test_v2_url_payload_includes_suppression_trace() -> None:
@@ -152,6 +159,11 @@ def test_v2_url_payload_includes_suppression_trace() -> None:
     row = suppression_trace["suppressed_rows"][0]
     assert row["module"] == "homoglyph"
     assert row["category"] == "HMG002_PUNYCODE_VISIBILITY"
+    assert row["finding_key"] == "homoglyph:HMG002_PUNYCODE_VISIBILITY"
+    assert row["compare_key"] == (
+        "homoglyph:HMG002_PUNYCODE_VISIBILITY:finding:hmg002_punycode_visibility"
+    )
+    assert row["sort_index"] == 0
     assert row["suppression_scope"] == "finding"
     assert row["matched_rule"] == "HMG002_PUNYCODE_VISIBILITY"
 

--- a/tests/formatters/test_structured.py
+++ b/tests/formatters/test_structured.py
@@ -129,14 +129,18 @@ def test_v2_url_payload_builds_redirect_trace_from_findings() -> None:
             risk_score=15,
             title="URL redirects before reaching a final destination",
             explanation="Redirect chain present.",
-            family_explanation="This link bounces through another address before it finishes loading.",
+            family_explanation=(
+                "This link bounces through another address before it finishes loading."
+            ),
             evidence=[
                 Evidence(label="Redirect Hops", value="2"),
                 Evidence(label="Chain", value="https://start.example -> https://mid.example -> https://final.example"),
                 Evidence(label="Start URL", value="https://start.example"),
                 Evidence(label="Final URL", value="https://final.example"),
             ],
-            recommendations=["Check the final destination before signing in or entering payment details."],
+            recommendations=[
+                "Check the final destination before signing in or entering payment details."
+            ],
         ),
         Finding(
             module="redirect",
@@ -146,11 +150,16 @@ def test_v2_url_payload_builds_redirect_trace_from_findings() -> None:
             risk_score=40,
             title="Redirect chain changes registrable domain",
             explanation="Cross-domain jumps increase destination uncertainty.",
-            family_explanation="This link starts on one site name and ends on a different site name.",
+            family_explanation=(
+                "This link starts on one site name and ends on a different site name."
+            ),
             evidence=[
                 Evidence(label="Redirect Hops", value="2"),
                 Evidence(label="Chain", value="https://start.example -> https://mid.example -> https://final.example"),
-                Evidence(label="Domain Path", value="start.example -> mid.example -> final.example"),
+                Evidence(
+                    label="Domain Path",
+                    value="start.example -> mid.example -> final.example",
+                ),
             ],
             recommendations=["Verify that the final site name is expected and trusted."],
         ),
@@ -272,4 +281,3 @@ def test_qr_payload_can_disable_legacy_keys_for_multi_mode() -> None:
     assert "items" in payload
     assert "image_path" not in payload
     assert "results" not in payload
-

--- a/tests/formatters/test_structured.py
+++ b/tests/formatters/test_structured.py
@@ -119,6 +119,43 @@ def test_v2_url_payload_includes_analyst_projection() -> None:
     assert evidence_rows[0]["cumulative_risk_score"] >= evidence_rows[-1]["cumulative_risk_score"]
 
 
+def test_v2_url_payload_includes_suppression_trace() -> None:
+    result = analyze_url(
+        "https://xn--pple-43d.com",
+        metadata={
+            "allowlist_domains": ["xn--pple-43d.com"],
+            "allowlist_categories": ["NONE"],
+            "allowlist_findings": ["HMG002_PUNYCODE_VISIBILITY"],
+        },
+    )
+    payload = build_single_result_payload(
+        flow="analyze",
+        input_type="url",
+        subject="https://xn--pple-43d.com",
+        result=result,
+        schema_version="2.0",
+    )
+
+    item = payload["item"]
+    assert isinstance(item, dict)
+    analyst = item["analyst"]
+    assert isinstance(analyst, dict)
+    suppression_trace = analyst["suppression_trace"]
+    assert isinstance(suppression_trace, dict)
+    assert suppression_trace["configured_allowlist_domains"] == [
+        "xn--pple-43d.com",
+        "\u0430pple.com",
+    ]
+    assert suppression_trace["configured_allowlist_categories"] == []
+    assert suppression_trace["configured_allowlist_findings"] == ["HMG002_PUNYCODE_VISIBILITY"]
+    assert suppression_trace["suppressed_count"] == 1
+    row = suppression_trace["suppressed_rows"][0]
+    assert row["module"] == "homoglyph"
+    assert row["category"] == "HMG002_PUNYCODE_VISIBILITY"
+    assert row["suppression_scope"] == "finding"
+    assert row["matched_rule"] == "HMG002_PUNYCODE_VISIBILITY"
+
+
 def test_v2_url_payload_builds_redirect_trace_from_findings() -> None:
     redirect_findings = [
         Finding(

--- a/ui/README.md
+++ b/ui/README.md
@@ -6,6 +6,7 @@ It is still intentionally lean, but `/analyze` now works as a real shared worksp
 - URL and email submit through `POST /api/v2/analyze`
 - QR remains available from the same page through `POST /api/v1/qr/scan` until v2 adds file input support
 - Quick and Analyst display modes share the same request surface
+- URL Analyst mode now renders contract summary, domain anatomy, redirect path, suppression trace, and evidence filtering from structured v2 payloads
 
 For the full product UX direction, see:
 
@@ -77,5 +78,6 @@ NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:8000 NEXT_PUBLIC_UI_ORIGIN=http://127.
 The Playwright smoke covers the unified `/analyze` page for:
 
 - URL submission through `POST /api/v2/analyze`
+- analyst-mode URL rendering of domain anatomy, redirect, suppression, and evidence panels from structured payloads
 - email-header submission through `POST /api/v2/analyze`
 - QR upload through `POST /api/v1/qr/scan`, asserting the structured error path when the decoded fixture is not a URL or QR decoding is unavailable

--- a/ui/app/analyze/page.tsx
+++ b/ui/app/analyze/page.tsx
@@ -78,7 +78,7 @@ const TAB_HELP: Record<AnalyzeTab, string> = {
 
 const MODE_COPY: Record<WorkspaceMode, string> = {
   quick: "Quick mode keeps the first verdict, top reasons, and next actions in view.",
-  analyst: "Analyst mode keeps contract details, domain anatomy, redirect path, and evidence in view."
+  analyst: "Analyst mode keeps contract details, domain anatomy, redirect path, suppression trace, and evidence in view."
 };
 
 function readStoredMode(): WorkspaceMode {

--- a/ui/app/analyze/page.tsx
+++ b/ui/app/analyze/page.tsx
@@ -1,22 +1,18 @@
 "use client";
 
 import { FormEvent, useEffect, useState } from "react";
+
 import {
   AnalyzeV2Request,
-  ApiItem,
   ApiRequestError,
   ApiWrappedResponse,
-  asPrettyJson,
   analyzeV2,
-  getPrimaryItem,
-  getResponseItems,
   scanQr
 } from "../../lib/api";
+import { AnalystResult, EmptyState, QuickResult } from "./result-panels";
 
 type AnalyzeTab = "url" | "email" | "qr";
 type WorkspaceMode = "quick" | "analyst";
-type ConfidenceLevel = "LOW" | "MEDIUM" | "HIGH";
-type ActionLevel = "safe" | "caution" | "avoid" | "block";
 
 const DEFAULT_EMAIL_HEADERS =
   "Authentication-Results: mx.example; spf=pass; dkim=pass; dmarc=pass\n";
@@ -24,75 +20,6 @@ const MODE_STORAGE_KEY = "lsh.analyze.mode";
 const ALLOWLIST_CATEGORY_OPTIONS = ["HMG", "ASCII", "URL", "NET", "ALL", "NONE"] as const;
 
 type AllowlistCategory = (typeof ALLOWLIST_CATEGORY_OPTIONS)[number];
-
-function readStoredMode(): WorkspaceMode {
-  if (typeof window === "undefined") {
-    return "quick";
-  }
-  const storedMode = window.localStorage.getItem(MODE_STORAGE_KEY);
-  return storedMode === "quick" || storedMode === "analyst" ? storedMode : "quick";
-}
-
-const TAB_LABELS: Record<AnalyzeTab, string> = {
-  url: "URL",
-  email: "Email",
-  qr: "QR"
-};
-
-const TAB_HELP: Record<AnalyzeTab, string> = {
-  url: "Paste a destination, tune false-positive controls, and optionally enable redirect analysis.",
-  email: "Paste raw email authentication headers and send them through the shared v2 analyze contract.",
-  qr: "Upload a QR image from the same workspace. QR still uses the v1 upload route until v2 adds file inputs."
-};
-
-const MODE_COPY: Record<WorkspaceMode, string> = {
-  quick: "Quick mode keeps the first verdict, top reasons, and next actions in view.",
-  analyst: "Analyst mode keeps contract details and raw JSON visible for deeper inspection."
-};
-
-const CONFIDENCE_RANK: Record<ConfidenceLevel, number> = {
-  LOW: 1,
-  MEDIUM: 2,
-  HIGH: 3
-};
-
-const ACTION_COPY: Record<
-  ActionLevel,
-  {
-    badge: string;
-    title: string;
-    detail: string;
-    fallbackRecommendation: string;
-  }
-> = {
-  safe: {
-    badge: "Safe",
-    title: "Safe to continue",
-    detail: "No strong warning signals were returned for this result.",
-    fallbackRecommendation:
-      "Proceed only if you expected this item, and use trusted bookmarks for sensitive accounts."
-  },
-  caution: {
-    badge: "Caution",
-    title: "Pause and verify",
-    detail: "A mild warning sign was found, so a quick verification step is still worth it.",
-    fallbackRecommendation: "Pause and verify the destination or sender before taking action."
-  },
-  avoid: {
-    badge: "Avoid",
-    title: "Avoid interacting for now",
-    detail: "This result shows strong warning signs that should stop a routine click-through.",
-    fallbackRecommendation:
-      "Avoid opening links, replying, or signing in until you verify the destination through a trusted path."
-  },
-  block: {
-    badge: "Block",
-    title: "Block and report",
-    detail: "This result has high-risk signals and should be treated as unsafe by default.",
-    fallbackRecommendation:
-      "Do not open or reply. Report it and use an official contact path instead."
-  }
-};
 
 interface UrlFormState {
   url: string;
@@ -137,9 +64,29 @@ interface RunState {
   lastSubmission: Submission | null;
 }
 
-interface VerdictContext {
-  flow: string;
-  inputType: string;
+const TAB_LABELS: Record<AnalyzeTab, string> = {
+  url: "URL",
+  email: "Email",
+  qr: "QR"
+};
+
+const TAB_HELP: Record<AnalyzeTab, string> = {
+  url: "Paste a destination, tune false-positive controls, and optionally enable redirect analysis.",
+  email: "Paste raw email authentication headers and send them through the shared v2 analyze contract.",
+  qr: "Upload a QR image from the same workspace. QR still uses the v1 upload route until v2 adds file inputs."
+};
+
+const MODE_COPY: Record<WorkspaceMode, string> = {
+  quick: "Quick mode keeps the first verdict, top reasons, and next actions in view.",
+  analyst: "Analyst mode keeps contract details, domain anatomy, redirect path, and evidence in view."
+};
+
+function readStoredMode(): WorkspaceMode {
+  if (typeof window === "undefined") {
+    return "quick";
+  }
+  const storedMode = window.localStorage.getItem(MODE_STORAGE_KEY);
+  return storedMode === "quick" || storedMode === "analyst" ? storedMode : "quick";
 }
 
 function parseTokenList(raw: string): string[] {
@@ -147,290 +94,6 @@ function parseTokenList(raw: string): string[] {
     .split(/[\s,]+/)
     .map((item) => item.trim())
     .filter(Boolean);
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function getString(value: unknown): string | null {
-  return typeof value === "string" && value.trim().length > 0 ? value : null;
-}
-
-function getNumber(value: unknown): number | null {
-  return typeof value === "number" && Number.isFinite(value) ? value : null;
-}
-
-function getConfidenceLevel(value: unknown): ConfidenceLevel | null {
-  if (value === "LOW" || value === "MEDIUM" || value === "HIGH") {
-    return value;
-  }
-  return null;
-}
-
-function getFindings(item: ApiItem): Record<string, unknown>[] {
-  const findings = item.result.findings;
-  if (!Array.isArray(findings)) {
-    return [];
-  }
-  return findings.filter(isRecord);
-}
-
-function getRankedFindings(item: ApiItem): Record<string, unknown>[] {
-  return [...getFindings(item)].sort((left, right) => {
-    const riskDelta = (getNumber(right.risk_score) ?? 0) - (getNumber(left.risk_score) ?? 0);
-    if (riskDelta !== 0) {
-      return riskDelta;
-    }
-
-    const confidenceDelta =
-      (CONFIDENCE_RANK[getConfidenceLevel(right.confidence) ?? "LOW"] ?? 0) -
-      (CONFIDENCE_RANK[getConfidenceLevel(left.confidence) ?? "LOW"] ?? 0);
-    if (confidenceDelta !== 0) {
-      return confidenceDelta;
-    }
-
-    return (getString(left.title) ?? "").localeCompare(getString(right.title) ?? "");
-  });
-}
-
-function dedupeStrings(values: string[]): string[] {
-  return [...new Set(values)];
-}
-
-function isEmailContext(context: VerdictContext): boolean {
-  return context.inputType === "email_headers" || context.inputType === "email_file";
-}
-
-function isQrContext(context: VerdictContext): boolean {
-  return context.flow === "qr_scan";
-}
-
-function rewriteReason(reason: string, context: VerdictContext): string {
-  if (isEmailContext(context)) {
-    if (/sender server did not pass.*SPF/i.test(reason)) {
-      return "The sender check failed, so this message may not be from who it claims.";
-    }
-    if (/signed authenticity check \(DKIM\) did not pass/i.test(reason)) {
-      return "The message signature check failed, which can mean spoofing or tampering.";
-    }
-    if (/domain policy check \(DMARC\) failed/i.test(reason)) {
-      return "The sender domain did not match its own policy, which is a strong warning sign.";
-    }
-    if (/weak or missing SPF/i.test(reason)) {
-      return "A sender check is weak or missing, so trust is lower than normal.";
-    }
-    if (/weak or missing DKIM/i.test(reason)) {
-      return "A message signature check is weak or missing, so trust is lower than normal.";
-    }
-    if (/weak or missing DMARC/i.test(reason)) {
-      return "A sender-domain policy check is weak or missing, so this message deserves extra caution.";
-    }
-    if (/did not include standard authentication results/i.test(reason)) {
-      return "Standard sender-verification results are missing, so trust checks are limited.";
-    }
-  }
-
-  if (/hidden technical form \(`xn--\.\.\.`\)/i.test(reason)) {
-    return "Part of this link is encoded in a way often used by lookalike domains.";
-  }
-
-  return reason;
-}
-
-function rewriteRecommendation(recommendation: string, context: VerdictContext): string {
-  if (isEmailContext(context)) {
-    if (/Treat the message as suspicious until independently verified\./i.test(recommendation)) {
-      return "Treat this message as suspicious until you verify it another way.";
-    }
-    if (/Do not act on sensitive requests until verified independently\./i.test(recommendation)) {
-      return "Do not follow sensitive requests until you verify them another way.";
-    }
-    if (/Use caution before trusting links or requests in this message\./i.test(recommendation)) {
-      return "Be careful with links or requests in this message until you verify the sender.";
-    }
-  }
-
-  return recommendation;
-}
-
-function getReasons(item: ApiItem, context: VerdictContext): string[] {
-  if (item.family?.reasons?.length) {
-    return dedupeStrings(item.family.reasons.map((reason) => rewriteReason(reason, context))).slice(
-      0,
-      3
-    );
-  }
-
-  const reasons = getRankedFindings(item)
-    .map((finding) => getString(finding.family_explanation) ?? getString(finding.explanation))
-    .filter((reason): reason is string => reason !== null)
-    .map((reason) => rewriteReason(reason, context));
-
-  return dedupeStrings(reasons).slice(0, 3);
-}
-
-function getRecommendations(item: ApiItem, context: VerdictContext): string[] {
-  if (item.family?.recommendations?.length) {
-    return dedupeStrings(
-      item.family.recommendations.map((recommendation) =>
-        rewriteRecommendation(recommendation, context)
-      )
-    ).slice(0, 3);
-  }
-
-  const recommendations = new Set<string>();
-  for (const finding of getRankedFindings(item)) {
-    const rawRecommendations = finding.recommendations;
-    if (!Array.isArray(rawRecommendations)) {
-      continue;
-    }
-    for (const recommendation of rawRecommendations) {
-      const parsedRecommendation = getString(recommendation);
-      if (parsedRecommendation) {
-        recommendations.add(rewriteRecommendation(parsedRecommendation, context));
-      }
-    }
-  }
-
-  return [...recommendations].slice(0, 3);
-}
-
-function getSeverity(item: ApiItem): string {
-  return getString(item.family?.severity) ?? getString(item.result.overall_severity) ?? "UNKNOWN";
-}
-
-function getConfidence(item: ApiItem): ConfidenceLevel | null {
-  const familyConfidence = getConfidenceLevel(item.family?.signal_confidence);
-  if (familyConfidence) {
-    return familyConfidence;
-  }
-
-  const findingConfidence = getRankedFindings(item)
-    .map((finding) => getConfidenceLevel(finding.confidence))
-    .find((confidence): confidence is ConfidenceLevel => confidence !== null);
-
-  return findingConfidence ?? null;
-}
-
-function getSummary(item: ApiItem): string {
-  return getString(item.family?.summary) ?? getString(item.result.summary) ?? "Analysis completed.";
-}
-
-function getRiskScore(item: ApiItem): number | null {
-  return getNumber(item.family?.risk_score) ?? getNumber(item.result.overall_risk);
-}
-
-function getFindingCount(item: ApiItem): number {
-  return getFindings(item).length;
-}
-
-function getActionLevel(item: ApiItem): ActionLevel {
-  const riskScore = getRiskScore(item) ?? 0;
-  const severity = getSeverity(item);
-
-  if (riskScore >= 81 || severity === "CRITICAL") {
-    return "block";
-  }
-  if (riskScore >= 61 || severity === "HIGH") {
-    return "avoid";
-  }
-  if (riskScore >= 21 || severity === "MEDIUM" || severity === "LOW" || getFindingCount(item) > 0) {
-    return "caution";
-  }
-  return "safe";
-}
-
-function getPrimaryRecommendation(
-  item: ApiItem,
-  actionLevel: ActionLevel,
-  context: VerdictContext
-): string {
-  return getRecommendations(item, context)[0] ?? ACTION_COPY[actionLevel].fallbackRecommendation;
-}
-
-function getConfidenceNote(confidence: ConfidenceLevel | null): string {
-  if (confidence === "HIGH") {
-    return "High-confidence signals support this verdict.";
-  }
-  if (confidence === "MEDIUM") {
-    return "Signal confidence is moderate, so context still matters.";
-  }
-  if (confidence === "LOW") {
-    return "Signals are limited, so verify before acting.";
-  }
-  return "No confidence label was returned for this result.";
-}
-
-function getPlainLanguageSummary(item: ApiItem, context: VerdictContext): string {
-  const actionLevel = getActionLevel(item);
-
-  if (isEmailContext(context)) {
-    if (actionLevel === "safe") {
-      return "No major trust problems were found in these email headers.";
-    }
-    if (actionLevel === "caution") {
-      return "This message is missing some trust signals, so verify it before acting.";
-    }
-    if (actionLevel === "avoid") {
-      return "This message shows strong signs that it may not be trustworthy.";
-    }
-    return "This message failed key trust checks and should be treated as suspicious.";
-  }
-
-  if (isQrContext(context)) {
-    if (actionLevel === "safe") {
-      return "The QR code was read and the selected destination did not show strong warning signs.";
-    }
-    if (actionLevel === "caution") {
-      return "The QR code leads to a destination with some warning signs, so verify it before opening.";
-    }
-    if (actionLevel === "avoid") {
-      return "The QR code leads to a destination that should be avoided for now.";
-    }
-    return "The QR code leads to a destination that looks unsafe.";
-  }
-
-  if (actionLevel === "safe") {
-    return "This destination did not show strong warning signs in this scan.";
-  }
-  if (actionLevel === "caution") {
-    return "This destination has some warning signs, so verify it before opening.";
-  }
-  if (actionLevel === "avoid") {
-    return "This destination shows strong warning signs and should be avoided for now.";
-  }
-  return "This destination looks unsafe and should be blocked or reported.";
-}
-
-function getVerdictDetail(actionLevel: ActionLevel, context: VerdictContext): string {
-  if (isEmailContext(context)) {
-    if (actionLevel === "safe") {
-      return "The visible sender checks look normal enough that this message does not need an immediate block.";
-    }
-    if (actionLevel === "caution") {
-      return "Some sender checks are missing or weak, so this message deserves a second look.";
-    }
-    if (actionLevel === "avoid") {
-      return "Several sender checks failed or degraded, which raises spoofing risk.";
-    }
-    return "Multiple sender checks failed, which is common in spoofed or malicious messages.";
-  }
-
-  if (isQrContext(context)) {
-    if (actionLevel === "safe") {
-      return "The QR code resolved cleanly and the visible destination did not trigger major warnings.";
-    }
-    if (actionLevel === "caution") {
-      return "The QR code resolved, but the destination still deserves a quick verification step.";
-    }
-    if (actionLevel === "avoid") {
-      return "The QR code resolves to a destination that should not be trusted casually.";
-    }
-    return "The QR code resolves to a destination with high-risk signals.";
-  }
-
-  return ACTION_COPY[actionLevel].detail;
 }
 
 function formatRequestError(error: unknown): string {
@@ -498,204 +161,6 @@ function endpointLabel(submission: Submission | null): string | null {
     return "POST /api/v1/qr/scan";
   }
   return "POST /api/v2/analyze";
-}
-
-function MetricCard({ label, value }: { label: string; value: string }) {
-  return (
-    <div className="metricCard">
-      <span className="metricLabel">{label}</span>
-      <span className="metricValue">{value}</span>
-    </div>
-  );
-}
-
-function VerdictCard({ item, context }: { item: ApiItem; context: VerdictContext }) {
-  const riskScore = getRiskScore(item);
-  const confidence = getConfidence(item);
-  const actionLevel = getActionLevel(item);
-  const primaryRecommendation = getPrimaryRecommendation(item, actionLevel, context);
-  const actionCopy = ACTION_COPY[actionLevel];
-
-  return (
-    <section className={`verdictCard verdictCard-${actionLevel}`}>
-      <div className="verdictHeader">
-        <div>
-          <p className="eyebrow">Primary verdict</p>
-          <h3>{actionCopy.title}</h3>
-        </div>
-        <span className={`actionPill actionPill-${actionLevel}`}>Action: {actionCopy.badge}</span>
-      </div>
-
-      <p className="verdictSummary">{getPlainLanguageSummary(item, context)}</p>
-      <p className="muted compactText">{getVerdictDetail(actionLevel, context)}</p>
-
-      <div className="verdictPrimaryAction">
-        <span className="metricLabel">Recommended next step</span>
-        <strong>{primaryRecommendation}</strong>
-      </div>
-
-      <div className="badgeRow">
-        <span className="badge">Subject: {item.subject}</span>
-        <span className="badge">Risk: {riskScore !== null ? String(riskScore) : "-"}</span>
-        <span className="badge">Findings: {String(getFindingCount(item))}</span>
-        <span className="badge">Flow: {context.flow}</span>
-        <span className="badge">
-          Confidence: {confidence ?? "Not provided"}
-        </span>
-      </div>
-
-      <p className="verdictConfidence">{getConfidenceNote(confidence)}</p>
-    </section>
-  );
-}
-
-function WhyPanel({ item, context }: { item: ApiItem; context: VerdictContext }) {
-  const actionLevel = getActionLevel(item);
-  const reasons = getReasons(item, context);
-  const recommendations = getRecommendations(item, context);
-  const nextSteps =
-    recommendations.length > 0
-      ? recommendations
-      : [ACTION_COPY[actionLevel].fallbackRecommendation];
-
-  return (
-    <div className="resultList">
-      <section className="miniCard">
-        <h3>Why this verdict</h3>
-        {reasons.length > 0 ? (
-          <ol className="rankedList">
-            {reasons.map((reason) => (
-              <li key={reason}>{reason}</li>
-            ))}
-          </ol>
-        ) : (
-          <p className="muted">No reason strings were returned for this item.</p>
-        )}
-      </section>
-
-      <section className="miniCard">
-        <h3>Next actions</h3>
-        <ul className="cleanList">
-          {nextSteps.map((recommendation) => (
-            <li key={recommendation}>{recommendation}</li>
-          ))}
-        </ul>
-      </section>
-    </div>
-  );
-}
-
-function QuickResult({ response }: { response: ApiWrappedResponse }) {
-  const primaryItem = getPrimaryItem(response);
-  if (!primaryItem) {
-    return <p className="muted">The API returned no items.</p>;
-  }
-
-  const items = getResponseItems(response);
-  const context: VerdictContext = {
-    flow: response.flow,
-    inputType: response.input_type
-  };
-
-  return (
-    <>
-      <VerdictCard item={primaryItem} context={context} />
-      <WhyPanel item={primaryItem} context={context} />
-
-      {items.length > 1 ? (
-        <section className="miniCard">
-          <h3>Additional decoded items</h3>
-          <div className="resultListCompact">
-            {items.slice(1).map((item) => (
-              <article className="miniCard insetCard" key={item.subject}>
-                <strong>{item.subject}</strong>
-                <p className="muted compactText">{getSummary(item)}</p>
-                <div className="badgeRow">
-                  <span className="badge">Action: {ACTION_COPY[getActionLevel(item)].badge}</span>
-                  <span className="badge">
-                    Risk: {getRiskScore(item) !== null ? String(getRiskScore(item)) : "-"}
-                  </span>
-                </div>
-              </article>
-            ))}
-          </div>
-        </section>
-      ) : null}
-    </>
-  );
-}
-
-function AnalystResult({ response }: { response: ApiWrappedResponse }) {
-  const items = getResponseItems(response);
-  const primaryItem = getPrimaryItem(response);
-
-  return (
-    <div className="resultList">
-      <section className="miniCard">
-        <h3>Contract summary</h3>
-        <div className="summaryGrid">
-          <MetricCard label="Schema" value={response.schema_version} />
-          <MetricCard label="Flow" value={response.flow} />
-          <MetricCard label="Mode" value={response.mode} />
-          <MetricCard label="Items" value={String(response.item_count)} />
-          <MetricCard label="Input type" value={response.input_type} />
-          <MetricCard label="Primary subject" value={primaryItem?.subject ?? "-"} />
-        </div>
-      </section>
-
-      {primaryItem ? (
-        <section className="miniCard">
-          <h3>Primary item snapshot</h3>
-          <div className="summaryGrid">
-            <MetricCard label="Severity" value={getSeverity(primaryItem)} />
-            <MetricCard
-              label="Risk"
-              value={getRiskScore(primaryItem) !== null ? String(getRiskScore(primaryItem)) : "-"}
-            />
-            <MetricCard label="Findings" value={String(getFindingCount(primaryItem))} />
-            <MetricCard
-              label="Confidence"
-              value={getString(primaryItem.family?.signal_confidence) ?? "-"}
-            />
-          </div>
-          <p className="compactText">{getSummary(primaryItem)}</p>
-        </section>
-      ) : null}
-
-      <section className="miniCard">
-        <h3>Returned subjects</h3>
-        {items.length > 0 ? (
-          <ul className="cleanList">
-            {items.map((item) => (
-              <li key={item.subject}>
-                {item.subject} ({getSeverity(item)}, risk {getRiskScore(item) ?? "-"})
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="muted">No item subjects were returned.</p>
-        )}
-      </section>
-
-      <section className="miniCard">
-        <h3>Raw JSON</h3>
-        <pre>{asPrettyJson(response)}</pre>
-      </section>
-    </div>
-  );
-}
-
-function EmptyState() {
-  return (
-    <section className="statusPanel">
-      <p className="eyebrow">Ready</p>
-      <h3>Run an analysis from the left panel</h3>
-      <p className="muted">
-        This workspace always asks the API for family summaries so Quick mode can render a verdict
-        without falling back to raw JSON.
-      </p>
-    </section>
-  );
 }
 
 export default function AnalyzePage() {
@@ -1155,4 +620,3 @@ export default function AnalyzePage() {
     </>
   );
 }
-

--- a/ui/app/analyze/result-panels.tsx
+++ b/ui/app/analyze/result-panels.tsx
@@ -1,0 +1,825 @@
+"use client";
+
+import { useDeferredValue, useState } from "react";
+import {
+  ApiAnalystEvidenceRow,
+  ApiDomainAnatomy,
+  ApiFinding,
+  ApiItem,
+  ApiRedirectTrace,
+  ApiWrappedResponse,
+  asPrettyJson,
+  getPrimaryItem,
+  getResponseItems
+} from "../../lib/api";
+
+type ConfidenceLevel = "LOW" | "MEDIUM" | "HIGH";
+type ActionLevel = "safe" | "caution" | "avoid" | "block";
+
+interface VerdictContext {
+  flow: string;
+  inputType: string;
+}
+
+const CONFIDENCE_RANK: Record<ConfidenceLevel, number> = {
+  LOW: 1,
+  MEDIUM: 2,
+  HIGH: 3
+};
+
+const ACTION_COPY: Record<
+  ActionLevel,
+  {
+    badge: string;
+    title: string;
+    detail: string;
+    fallbackRecommendation: string;
+  }
+> = {
+  safe: {
+    badge: "Safe",
+    title: "Safe to continue",
+    detail: "No strong warning signals were returned for this result.",
+    fallbackRecommendation:
+      "Proceed only if you expected this item, and use trusted bookmarks for sensitive accounts."
+  },
+  caution: {
+    badge: "Caution",
+    title: "Pause and verify",
+    detail: "A mild warning sign was found, so a quick verification step is still worth it.",
+    fallbackRecommendation: "Pause and verify the destination or sender before taking action."
+  },
+  avoid: {
+    badge: "Avoid",
+    title: "Avoid interacting for now",
+    detail: "This result shows strong warning signs that should stop a routine click-through.",
+    fallbackRecommendation:
+      "Avoid opening links, replying, or signing in until you verify the destination through a trusted path."
+  },
+  block: {
+    badge: "Block",
+    title: "Block and report",
+    detail: "This result has high-risk signals and should be treated as unsafe by default.",
+    fallbackRecommendation:
+      "Do not open or reply. Report it and use an official contact path instead."
+  }
+};
+
+
+function getString(value: unknown): string | null {
+  return typeof value === "string" && value.trim().length > 0 ? value : null;
+}
+
+function getNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function getConfidenceLevel(value: unknown): ConfidenceLevel | null {
+  if (value === "LOW" || value === "MEDIUM" || value === "HIGH") {
+    return value;
+  }
+  return null;
+}
+
+function getFindings(item: ApiItem): ApiFinding[] {
+  return item.result.findings;
+}
+
+function getRankedFindings(item: ApiItem): ApiFinding[] {
+  return [...getFindings(item)].sort((left, right) => {
+    const riskDelta = (getNumber(right.risk_score) ?? 0) - (getNumber(left.risk_score) ?? 0);
+    if (riskDelta !== 0) {
+      return riskDelta;
+    }
+
+    const confidenceDelta =
+      (CONFIDENCE_RANK[getConfidenceLevel(right.confidence) ?? "LOW"] ?? 0) -
+      (CONFIDENCE_RANK[getConfidenceLevel(left.confidence) ?? "LOW"] ?? 0);
+    if (confidenceDelta !== 0) {
+      return confidenceDelta;
+    }
+
+    return (getString(left.title) ?? "").localeCompare(getString(right.title) ?? "");
+  });
+}
+
+function dedupeStrings(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function isEmailContext(context: VerdictContext): boolean {
+  return context.inputType === "email_headers" || context.inputType === "email_file";
+}
+
+function isQrContext(context: VerdictContext): boolean {
+  return context.flow === "qr_scan";
+}
+
+function rewriteReason(reason: string, context: VerdictContext): string {
+  if (isEmailContext(context)) {
+    if (/sender server did not pass.*SPF/i.test(reason)) {
+      return "The sender check failed, so this message may not be from who it claims.";
+    }
+    if (/signed authenticity check \(DKIM\) did not pass/i.test(reason)) {
+      return "The message signature check failed, which can mean spoofing or tampering.";
+    }
+    if (/domain policy check \(DMARC\) failed/i.test(reason)) {
+      return "The sender domain did not match its own policy, which is a strong warning sign.";
+    }
+    if (/weak or missing SPF/i.test(reason)) {
+      return "A sender check is weak or missing, so trust is lower than normal.";
+    }
+    if (/weak or missing DKIM/i.test(reason)) {
+      return "A message signature check is weak or missing, so trust is lower than normal.";
+    }
+    if (/weak or missing DMARC/i.test(reason)) {
+      return "A sender-domain policy check is weak or missing, so this message deserves extra caution.";
+    }
+    if (/did not include standard authentication results/i.test(reason)) {
+      return "Standard sender-verification results are missing, so trust checks are limited.";
+    }
+  }
+
+  if (/hidden technical form \(`xn--\.\.\.`\)/i.test(reason)) {
+    return "Part of this link is encoded in a way often used by lookalike domains.";
+  }
+
+  return reason;
+}
+
+function rewriteRecommendation(recommendation: string, context: VerdictContext): string {
+  if (isEmailContext(context)) {
+    if (/Treat the message as suspicious until independently verified\./i.test(recommendation)) {
+      return "Treat this message as suspicious until you verify it another way.";
+    }
+    if (/Do not act on sensitive requests until verified independently\./i.test(recommendation)) {
+      return "Do not follow sensitive requests until you verify them another way.";
+    }
+    if (/Use caution before trusting links or requests in this message\./i.test(recommendation)) {
+      return "Be careful with links or requests in this message until you verify the sender.";
+    }
+  }
+
+  return recommendation;
+}
+
+function getReasons(item: ApiItem, context: VerdictContext): string[] {
+  if (item.family?.reasons?.length) {
+    return dedupeStrings(item.family.reasons.map((reason) => rewriteReason(reason, context))).slice(
+      0,
+      3
+    );
+  }
+
+  const reasons = getRankedFindings(item)
+    .map((finding) => getString(finding.family_explanation) ?? getString(finding.explanation))
+    .filter((reason): reason is string => reason !== null)
+    .map((reason) => rewriteReason(reason, context));
+
+  return dedupeStrings(reasons).slice(0, 3);
+}
+
+function getRecommendations(item: ApiItem, context: VerdictContext): string[] {
+  if (item.family?.recommendations?.length) {
+    return dedupeStrings(
+      item.family.recommendations.map((recommendation) =>
+        rewriteRecommendation(recommendation, context)
+      )
+    ).slice(0, 3);
+  }
+
+  const recommendations = new Set<string>();
+  for (const finding of getRankedFindings(item)) {
+    const rawRecommendations = finding.recommendations;
+    if (!Array.isArray(rawRecommendations)) {
+      continue;
+    }
+    for (const recommendation of rawRecommendations) {
+      const parsedRecommendation = getString(recommendation);
+      if (parsedRecommendation) {
+        recommendations.add(rewriteRecommendation(parsedRecommendation, context));
+      }
+    }
+  }
+
+  return [...recommendations].slice(0, 3);
+}
+
+function getSeverity(item: ApiItem): string {
+  return getString(item.family?.severity) ?? getString(item.result.overall_severity) ?? "UNKNOWN";
+}
+
+function getConfidence(item: ApiItem): ConfidenceLevel | null {
+  const familyConfidence = getConfidenceLevel(item.family?.signal_confidence);
+  if (familyConfidence) {
+    return familyConfidence;
+  }
+
+  const findingConfidence = getRankedFindings(item)
+    .map((finding) => getConfidenceLevel(finding.confidence))
+    .find((confidence): confidence is ConfidenceLevel => confidence !== null);
+
+  return findingConfidence ?? null;
+}
+
+function getSummary(item: ApiItem): string {
+  return getString(item.family?.summary) ?? getString(item.result.summary) ?? "Analysis completed.";
+}
+
+function getRiskScore(item: ApiItem): number | null {
+  return getNumber(item.family?.risk_score) ?? getNumber(item.result.overall_risk);
+}
+
+function getFindingCount(item: ApiItem): number {
+  return getFindings(item).length;
+}
+
+function getActionLevel(item: ApiItem): ActionLevel {
+  const riskScore = getRiskScore(item) ?? 0;
+  const severity = getSeverity(item);
+
+  if (riskScore >= 81 || severity === "CRITICAL") {
+    return "block";
+  }
+  if (riskScore >= 61 || severity === "HIGH") {
+    return "avoid";
+  }
+  if (riskScore >= 21 || severity === "MEDIUM" || severity === "LOW" || getFindingCount(item) > 0) {
+    return "caution";
+  }
+  return "safe";
+}
+
+function getPrimaryRecommendation(
+  item: ApiItem,
+  actionLevel: ActionLevel,
+  context: VerdictContext
+): string {
+  return getRecommendations(item, context)[0] ?? ACTION_COPY[actionLevel].fallbackRecommendation;
+}
+
+function getConfidenceNote(confidence: ConfidenceLevel | null): string {
+  if (confidence === "HIGH") {
+    return "High-confidence signals support this verdict.";
+  }
+  if (confidence === "MEDIUM") {
+    return "Signal confidence is moderate, so context still matters.";
+  }
+  if (confidence === "LOW") {
+    return "Signals are limited, so verify before acting.";
+  }
+  return "No confidence label was returned for this result.";
+}
+
+function getPlainLanguageSummary(item: ApiItem, context: VerdictContext): string {
+  const actionLevel = getActionLevel(item);
+
+  if (isEmailContext(context)) {
+    if (actionLevel === "safe") {
+      return "No major trust problems were found in these email headers.";
+    }
+    if (actionLevel === "caution") {
+      return "This message is missing some trust signals, so verify it before acting.";
+    }
+    if (actionLevel === "avoid") {
+      return "This message shows strong signs that it may not be trustworthy.";
+    }
+    return "This message failed key trust checks and should be treated as suspicious.";
+  }
+
+  if (isQrContext(context)) {
+    if (actionLevel === "safe") {
+      return "The QR code was read and the selected destination did not show strong warning signs.";
+    }
+    if (actionLevel === "caution") {
+      return "The QR code leads to a destination with some warning signs, so verify it before opening.";
+    }
+    if (actionLevel === "avoid") {
+      return "The QR code leads to a destination that should be avoided for now.";
+    }
+    return "The QR code leads to a destination that looks unsafe.";
+  }
+
+  if (actionLevel === "safe") {
+    return "This destination did not show strong warning signs in this scan.";
+  }
+  if (actionLevel === "caution") {
+    return "This destination has some warning signs, so verify it before opening.";
+  }
+  if (actionLevel === "avoid") {
+    return "This destination shows strong warning signs and should be avoided for now.";
+  }
+  return "This destination looks unsafe and should be blocked or reported.";
+}
+
+function getVerdictDetail(actionLevel: ActionLevel, context: VerdictContext): string {
+  if (isEmailContext(context)) {
+    if (actionLevel === "safe") {
+      return "The visible sender checks look normal enough that this message does not need an immediate block.";
+    }
+    if (actionLevel === "caution") {
+      return "Some sender checks are missing or weak, so this message deserves a second look.";
+    }
+    if (actionLevel === "avoid") {
+      return "Several sender checks failed or degraded, which raises spoofing risk.";
+    }
+    return "Multiple sender checks failed, which is common in spoofed or malicious messages.";
+  }
+
+  if (isQrContext(context)) {
+    if (actionLevel === "safe") {
+      return "The QR code resolved cleanly and the visible destination did not trigger major warnings.";
+    }
+    if (actionLevel === "caution") {
+      return "The QR code resolved, but the destination still deserves a quick verification step.";
+    }
+    if (actionLevel === "avoid") {
+      return "The QR code resolves to a destination that should not be trusted casually.";
+    }
+    return "The QR code resolves to a destination with high-risk signals.";
+  }
+
+  return ACTION_COPY[actionLevel].detail;
+}
+
+function formatLabelList(values: string[]): string {
+  return values.length > 0 ? values.join(" / ") : "-";
+}
+
+function metricValue(value: string | number | null | undefined): string {
+  if (value === null || value === undefined) {
+    return "-";
+  }
+  return String(value);
+}
+
+function rowMatchesSearch(row: ApiAnalystEvidenceRow, search: string): boolean {
+  if (!search) {
+    return true;
+  }
+  const haystack = [
+    row.module,
+    row.category,
+    row.title,
+    row.explanation,
+    row.family_explanation,
+    ...row.recommendations,
+    ...row.evidence.map((entry) => `${entry.label} ${entry.value}`)
+  ]
+    .join(" ")
+    .toLowerCase();
+  return haystack.includes(search);
+}
+
+function MetricCard({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="metricCard">
+      <span className="metricLabel">{label}</span>
+      <span className="metricValue">{value}</span>
+    </div>
+  );
+}
+
+function VerdictCard({ item, context }: { item: ApiItem; context: VerdictContext }) {
+  const riskScore = getRiskScore(item);
+  const confidence = getConfidence(item);
+  const actionLevel = getActionLevel(item);
+  const primaryRecommendation = getPrimaryRecommendation(item, actionLevel, context);
+  const actionCopy = ACTION_COPY[actionLevel];
+
+  return (
+    <section className={`verdictCard verdictCard-${actionLevel}`}>
+      <div className="verdictHeader">
+        <div>
+          <p className="eyebrow">Primary verdict</p>
+          <h3>{actionCopy.title}</h3>
+        </div>
+        <span className={`actionPill actionPill-${actionLevel}`}>Action: {actionCopy.badge}</span>
+      </div>
+
+      <p className="verdictSummary">{getPlainLanguageSummary(item, context)}</p>
+      <p className="muted compactText">{getVerdictDetail(actionLevel, context)}</p>
+
+      <div className="verdictPrimaryAction">
+        <span className="metricLabel">Recommended next step</span>
+        <strong>{primaryRecommendation}</strong>
+      </div>
+
+      <div className="badgeRow">
+        <span className="badge">Subject: {item.subject}</span>
+        <span className="badge">Risk: {riskScore !== null ? String(riskScore) : "-"}</span>
+        <span className="badge">Findings: {String(getFindingCount(item))}</span>
+        <span className="badge">Flow: {context.flow}</span>
+        <span className="badge">Confidence: {confidence ?? "Not provided"}</span>
+      </div>
+
+      <p className="verdictConfidence">{getConfidenceNote(confidence)}</p>
+    </section>
+  );
+}
+
+function WhyPanel({ item, context }: { item: ApiItem; context: VerdictContext }) {
+  const actionLevel = getActionLevel(item);
+  const reasons = getReasons(item, context);
+  const recommendations = getRecommendations(item, context);
+  const nextSteps =
+    recommendations.length > 0
+      ? recommendations
+      : [ACTION_COPY[actionLevel].fallbackRecommendation];
+
+  return (
+    <div className="resultList">
+      <section className="miniCard">
+        <h3>Why this verdict</h3>
+        {reasons.length > 0 ? (
+          <ol className="rankedList">
+            {reasons.map((reason) => (
+              <li key={reason}>{reason}</li>
+            ))}
+          </ol>
+        ) : (
+          <p className="muted">No reason strings were returned for this item.</p>
+        )}
+      </section>
+
+      <section className="miniCard">
+        <h3>Next actions</h3>
+        <ul className="cleanList">
+          {nextSteps.map((recommendation) => (
+            <li key={recommendation}>{recommendation}</li>
+          ))}
+        </ul>
+      </section>
+    </div>
+  );
+}
+
+function DomainAnatomy({ anatomy }: { anatomy: ApiDomainAnatomy }) {
+  return (
+    <section className="miniCard">
+      <div className="panelHeaderRow">
+        <div>
+          <h3>Domain anatomy</h3>
+          <p className="muted compactText">Normalized host and label breakdown for the submitted URL.</p>
+        </div>
+      </div>
+      <div className="summaryGrid analystSummaryGrid">
+        <MetricCard label="Submitted URL" value={anatomy.submitted_url} />
+        <MetricCard label="Canonical URL" value={anatomy.canonical_url} />
+        <MetricCard label="Hostname" value={metricValue(anatomy.hostname)} />
+        <MetricCard label="Registrable domain" value={metricValue(anatomy.registrable_domain)} />
+        <MetricCard label="Canonical host" value={metricValue(anatomy.canonical_hostname)} />
+        <MetricCard
+          label="Canonical registrable"
+          value={metricValue(anatomy.canonical_registrable_domain)}
+        />
+        <MetricCard label="Subdomain labels" value={formatLabelList(anatomy.subdomain_labels)} />
+        <MetricCard
+          label="Registrable labels"
+          value={formatLabelList(anatomy.registrable_labels)}
+        />
+        <MetricCard label="IDNA ASCII" value={metricValue(anatomy.idna_ascii_hostname)} />
+        <MetricCard label="IDNA Unicode" value={metricValue(anatomy.idna_unicode_hostname)} />
+        <MetricCard label="IP literal" value={anatomy.is_ip_literal ? "Yes" : "No"} />
+        <MetricCard label="Literal value" value={metricValue(anatomy.ip_literal)} />
+        <MetricCard label="Obfuscated IPv4" value={metricValue(anatomy.obfuscated_ipv4)} />
+        <MetricCard label="IPv6 mapped IPv4" value={metricValue(anatomy.ipv6_mapped_ipv4)} />
+      </div>
+      {anatomy.obfuscated_ipv4_notes.length > 0 ? (
+        <div className="anatomyNoteGroup">
+          <strong>Obfuscation notes</strong>
+          <ul className="cleanList">
+            {anatomy.obfuscated_ipv4_notes.map((note) => (
+              <li key={note}>{note}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+      {anatomy.normalization_notes.length > 0 ? (
+        <div className="anatomyNoteGroup">
+          <strong>Normalization notes</strong>
+          <ul className="cleanList">
+            {anatomy.normalization_notes.map((note) => (
+              <li key={note}>{note}</li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function RedirectPathView({ trace }: { trace: ApiRedirectTrace }) {
+  const stateBadges = [
+    trace.crosses_registrable_domain ? "Cross-domain redirect" : null,
+    trace.max_hops_reached ? "Max hops reached" : null,
+    trace.timed_out ? "Timed out" : null,
+    trace.loop_target ? "Loop detected" : null,
+    trace.request_error ? "Request error" : null
+  ].filter((value): value is string => value !== null);
+
+  return (
+    <section className="miniCard">
+      <div className="panelHeaderRow">
+        <div>
+          <h3>Redirect path</h3>
+          <p className="muted compactText">Observed destination changes from the redirect analyzer.</p>
+        </div>
+        <span className="badge">Hops: {trace.hop_count}</span>
+      </div>
+      {stateBadges.length > 0 ? (
+        <div className="badgeRow analystBadgeRow">
+          {stateBadges.map((badge) => (
+            <span className="badge" key={badge}>
+              {badge}
+            </span>
+          ))}
+        </div>
+      ) : null}
+      <div className="redirectTimeline" role="list">
+        {trace.hops.map((hop, index) => (
+          <div className="redirectHop" role="listitem" key={`${hop}-${index}`}>
+            <span className="redirectStep">{index + 1}</span>
+            <div>
+              <strong>{hop}</strong>
+              <p className="muted compactText">
+                Registrable domain: {trace.registrable_domain_path[index] ?? "-"}
+              </p>
+            </div>
+          </div>
+        ))}
+      </div>
+      {trace.loop_target ? <p className="muted compactText">Loop target: {trace.loop_target}</p> : null}
+      {trace.request_error ? <p className="muted compactText">Request error: {trace.request_error}</p> : null}
+    </section>
+  );
+}
+
+function EvidencePanel({ rows }: { rows: ApiAnalystEvidenceRow[] }) {
+  const [search, setSearch] = useState("");
+  const [moduleFilter, setModuleFilter] = useState<string>("all");
+  const deferredSearch = useDeferredValue(search.trim().toLowerCase());
+  const modules = ["all", ...new Set(rows.map((row) => row.module))];
+  const filteredRows = rows.filter((row) => {
+    const matchesModule = moduleFilter === "all" || row.module === moduleFilter;
+    return matchesModule && rowMatchesSearch(row, deferredSearch);
+  });
+
+  return (
+    <section className="miniCard">
+      <div className="panelHeaderRow">
+        <div>
+          <h3>Evidence panel</h3>
+          <p className="muted compactText">Filter findings by detector module or free-text evidence.</p>
+        </div>
+        <span className="badge">Rows: {rows.length}</span>
+      </div>
+      <div className="evidenceToolbar">
+        <label className="searchField">
+          Search evidence
+          <input
+            value={search}
+            onChange={(event) => setSearch(event.target.value)}
+            placeholder="hostname, redirect, punycode..."
+          />
+        </label>
+        <div className="filterRow" aria-label="Filter evidence by module">
+          {modules.map((moduleName) => {
+            const active = moduleFilter === moduleName;
+            const label = moduleName === "all" ? "All modules" : moduleName;
+            return (
+              <button
+                key={moduleName}
+                type="button"
+                className={`chipButton${active ? " chipButtonActive" : ""}`}
+                onClick={() => setModuleFilter(moduleName)}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      {filteredRows.length > 0 ? (
+        <div className="resultListCompact">
+          {filteredRows.map((row) => (
+            <article className="evidenceCard" key={`${row.module}-${row.category}-${row.title}`}>
+              <div className="evidenceHeader">
+                <div>
+                  <h4>{row.title}</h4>
+                  <p className="muted compactText">{row.explanation}</p>
+                </div>
+                <div className="badgeRow analystBadgeRow">
+                  <span className="badge">{row.module}</span>
+                  <span className="badge">{row.category}</span>
+                  <span className="badge">Risk: {row.cumulative_risk_score}</span>
+                  <span className="badge">Confidence: {row.confidence}</span>
+                </div>
+              </div>
+              <p className="compactText">{row.family_explanation}</p>
+              {row.evidence.length > 0 ? (
+                <dl className="evidenceList">
+                  {row.evidence.map((entry) => (
+                    <div className="evidencePair" key={`${row.category}-${entry.label}-${entry.value}`}>
+                      <dt>{entry.label}</dt>
+                      <dd>{entry.value}</dd>
+                    </div>
+                  ))}
+                </dl>
+              ) : null}
+              {row.recommendations.length > 0 ? (
+                <div className="anatomyNoteGroup">
+                  <strong>Recommendations</strong>
+                  <ul className="cleanList">
+                    {row.recommendations.map((recommendation) => (
+                      <li key={recommendation}>{recommendation}</li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+            </article>
+          ))}
+        </div>
+      ) : (
+        <p className="muted">No evidence rows matched the current filters.</p>
+      )}
+    </section>
+  );
+}
+
+function AnalystFallback({ response }: { response: ApiWrappedResponse }) {
+  const items = getResponseItems(response);
+  const primaryItem = getPrimaryItem(response);
+
+  return (
+    <div className="resultList">
+      <section className="miniCard">
+        <h3>Contract summary</h3>
+        <div className="summaryGrid">
+          <MetricCard label="Schema" value={response.schema_version} />
+          <MetricCard label="Flow" value={response.flow} />
+          <MetricCard label="Mode" value={response.mode} />
+          <MetricCard label="Items" value={String(response.item_count)} />
+          <MetricCard label="Input type" value={response.input_type} />
+          <MetricCard label="Primary subject" value={primaryItem?.subject ?? "-"} />
+        </div>
+      </section>
+
+      {primaryItem ? (
+        <section className="miniCard">
+          <h3>Primary item snapshot</h3>
+          <div className="summaryGrid">
+            <MetricCard label="Severity" value={getSeverity(primaryItem)} />
+            <MetricCard
+              label="Risk"
+              value={getRiskScore(primaryItem) !== null ? String(getRiskScore(primaryItem)) : "-"}
+            />
+            <MetricCard label="Findings" value={String(getFindingCount(primaryItem))} />
+            <MetricCard
+              label="Confidence"
+              value={getString(primaryItem.family?.signal_confidence) ?? "-"}
+            />
+          </div>
+          <p className="compactText">{getSummary(primaryItem)}</p>
+        </section>
+      ) : null}
+
+      <section className="miniCard">
+        <h3>Returned subjects</h3>
+        {items.length > 0 ? (
+          <ul className="cleanList">
+            {items.map((item) => (
+              <li key={item.subject}>
+                {item.subject} ({getSeverity(item)}, risk {getRiskScore(item) ?? "-"})
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="muted">No item subjects were returned.</p>
+        )}
+      </section>
+
+      <section className="miniCard">
+        <h3>Raw JSON</h3>
+        <pre>{asPrettyJson(response)}</pre>
+      </section>
+    </div>
+  );
+}
+
+export function QuickResult({ response }: { response: ApiWrappedResponse }) {
+  const primaryItem = getPrimaryItem(response);
+  if (!primaryItem) {
+    return <p className="muted">The API returned no items.</p>;
+  }
+
+  const items = getResponseItems(response);
+  const context: VerdictContext = {
+    flow: response.flow,
+    inputType: response.input_type
+  };
+
+  return (
+    <>
+      <VerdictCard item={primaryItem} context={context} />
+      <WhyPanel item={primaryItem} context={context} />
+
+      {items.length > 1 ? (
+        <section className="miniCard">
+          <h3>Additional decoded items</h3>
+          <div className="resultListCompact">
+            {items.slice(1).map((item) => (
+              <article className="miniCard insetCard" key={item.subject}>
+                <strong>{item.subject}</strong>
+                <p className="muted compactText">{getSummary(item)}</p>
+                <div className="badgeRow">
+                  <span className="badge">Action: {ACTION_COPY[getActionLevel(item)].badge}</span>
+                  <span className="badge">
+                    Risk: {getRiskScore(item) !== null ? String(getRiskScore(item)) : "-"}
+                  </span>
+                </div>
+              </article>
+            ))}
+          </div>
+        </section>
+      ) : null}
+    </>
+  );
+}
+
+export function AnalystResult({ response }: { response: ApiWrappedResponse }) {
+  const items = getResponseItems(response);
+  const primaryItem = getPrimaryItem(response);
+  const analyst = response.input_type === "url" ? primaryItem?.analyst : undefined;
+
+  if (!primaryItem) {
+    return <p className="muted">The API returned no items.</p>;
+  }
+
+  if (!analyst) {
+    return <AnalystFallback response={response} />;
+  }
+
+  return (
+    <div className="resultList">
+      <section className="miniCard">
+        <h3>Contract summary</h3>
+        <div className="summaryGrid">
+          <MetricCard label="Schema" value={response.schema_version} />
+          <MetricCard label="Flow" value={response.flow} />
+          <MetricCard label="Mode" value={response.mode} />
+          <MetricCard label="Items" value={String(response.item_count)} />
+          <MetricCard label="Input type" value={response.input_type} />
+          <MetricCard label="Primary subject" value={primaryItem.subject} />
+        </div>
+      </section>
+
+      <section className="miniCard">
+        <h3>Primary item snapshot</h3>
+        <div className="summaryGrid">
+          <MetricCard label="Severity" value={getSeverity(primaryItem)} />
+          <MetricCard
+            label="Risk"
+            value={getRiskScore(primaryItem) !== null ? String(getRiskScore(primaryItem)) : "-"}
+          />
+          <MetricCard label="Findings" value={String(getFindingCount(primaryItem))} />
+          <MetricCard label="Confidence" value={getConfidence(primaryItem) ?? "-"} />
+        </div>
+        <p className="compactText">{getSummary(primaryItem)}</p>
+      </section>
+
+      <DomainAnatomy anatomy={analyst.domain_anatomy} />
+      {analyst.redirect_trace ? <RedirectPathView trace={analyst.redirect_trace} /> : null}
+      <EvidencePanel rows={analyst.evidence_rows} />
+
+      {items.length > 1 ? (
+        <section className="miniCard">
+          <h3>Returned subjects</h3>
+          <ul className="cleanList">
+            {items.map((item) => (
+              <li key={item.subject}>
+                {item.subject} ({getSeverity(item)}, risk {getRiskScore(item) ?? "-"})
+              </li>
+            ))}
+          </ul>
+        </section>
+      ) : null}
+    </div>
+  );
+}
+
+export function EmptyState() {
+  return (
+    <section className="statusPanel">
+      <p className="eyebrow">Ready</p>
+      <h3>Run an analysis from the left panel</h3>
+      <p className="muted">
+        This workspace always asks the API for family summaries so Quick mode can render a verdict
+        without falling back to raw JSON.
+      </p>
+    </section>
+  );
+}
+
+
+

--- a/ui/app/analyze/result-panels.tsx
+++ b/ui/app/analyze/result-panels.tsx
@@ -7,6 +7,7 @@ import {
   ApiFinding,
   ApiItem,
   ApiRedirectTrace,
+  ApiSuppressionTrace,
   ApiWrappedResponse,
   asPrettyJson,
   getPrimaryItem,
@@ -555,6 +556,75 @@ function RedirectPathView({ trace }: { trace: ApiRedirectTrace }) {
   );
 }
 
+function SuppressionTracePanel({ trace }: { trace: ApiSuppressionTrace }) {
+  return (
+    <section className="miniCard">
+      <div className="panelHeaderRow">
+        <div>
+          <h3>Suppression trace</h3>
+          <p className="muted compactText">
+            Allowlist rules that removed findings before the final analyst result was shaped.
+          </p>
+        </div>
+        <span className="badge">Suppressed: {trace.suppressed_count}</span>
+      </div>
+      <div className="summaryGrid analystSummaryGrid">
+        <MetricCard label="Hostname" value={metricValue(trace.hostname)} />
+        <MetricCard
+          label="Allowlist domains"
+          value={formatLabelList(trace.configured_allowlist_domains)}
+        />
+        <MetricCard
+          label="Category rules"
+          value={formatLabelList(trace.configured_allowlist_categories)}
+        />
+        <MetricCard
+          label="Finding rules"
+          value={formatLabelList(trace.configured_allowlist_findings)}
+        />
+        <MetricCard
+          label="Matched domains"
+          value={formatLabelList(trace.matched_allowlist_domains)}
+        />
+      </div>
+      {trace.suppressed_rows.length > 0 ? (
+        <div className="resultListCompact">
+          {trace.suppressed_rows.map((row) => (
+            <article
+              className="evidenceCard suppressionCard"
+              key={`${row.module}-${row.category}-${row.matched_rule}`}
+            >
+              <div className="evidenceHeader">
+                <div>
+                  <h4>{row.category}</h4>
+                  <p className="muted compactText">{row.reason}</p>
+                </div>
+                <div className="badgeRow analystBadgeRow">
+                  <span className="badge">{row.module}</span>
+                  <span className="badge">Scope: {row.suppression_scope}</span>
+                  <span className="badge">Rule: {row.matched_rule}</span>
+                </div>
+              </div>
+              <dl className="evidenceList">
+                <div className="evidencePair">
+                  <dt>Hostname</dt>
+                  <dd>{row.hostname}</dd>
+                </div>
+                <div className="evidencePair">
+                  <dt>Matched allowlist domain</dt>
+                  <dd>{row.matched_allowlist_domain}</dd>
+                </div>
+              </dl>
+            </article>
+          ))}
+        </div>
+      ) : (
+        <p className="muted">No findings were suppressed for the current allowlist inputs.</p>
+      )}
+    </section>
+  );
+}
+
 function EvidencePanel({ rows }: { rows: ApiAnalystEvidenceRow[] }) {
   const [search, setSearch] = useState("");
   const [moduleFilter, setModuleFilter] = useState<string>("all");
@@ -790,6 +860,7 @@ export function AnalystResult({ response }: { response: ApiWrappedResponse }) {
 
       <DomainAnatomy anatomy={analyst.domain_anatomy} />
       {analyst.redirect_trace ? <RedirectPathView trace={analyst.redirect_trace} /> : null}
+      {analyst.suppression_trace ? <SuppressionTracePanel trace={analyst.suppression_trace} /> : null}
       <EvidencePanel rows={analyst.evidence_rows} />
 
       {items.length > 1 ? (

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -447,3 +447,147 @@ pre {
   }
 }
 
+
+.panelHeaderRow {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.analystSummaryGrid {
+  margin-top: 10px;
+}
+
+.anatomyNoteGroup {
+  margin-top: 14px;
+  padding: 12px;
+  border-radius: 12px;
+  background: #f8fafc;
+  border: 1px solid var(--border);
+}
+
+.anatomyNoteGroup strong {
+  display: block;
+  margin-bottom: 8px;
+}
+
+.analystBadgeRow {
+  margin-top: 0;
+}
+
+.redirectTimeline {
+  display: grid;
+  gap: 10px;
+  margin-top: 14px;
+}
+
+.redirectHop {
+  display: grid;
+  grid-template-columns: 36px minmax(0, 1fr);
+  gap: 12px;
+  align-items: flex-start;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: #f8fafc;
+}
+
+.redirectStep {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 999px;
+  background: var(--text);
+  color: #ffffff;
+  font-weight: 800;
+}
+
+.evidenceToolbar {
+  display: grid;
+  gap: 12px;
+  margin-top: 14px;
+}
+
+.searchField {
+  margin-bottom: 0;
+}
+
+.filterRow {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.chipButton {
+  border: 1px solid var(--border);
+  background: #ffffff;
+  color: var(--text);
+  padding: 8px 12px;
+  border-radius: 999px;
+}
+
+.chipButtonActive {
+  background: var(--text);
+  color: #ffffff;
+}
+
+.evidenceCard {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 14px;
+  background: #fbfcfe;
+}
+
+.evidenceHeader {
+  display: grid;
+  gap: 10px;
+}
+
+.evidenceHeader h4 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.evidenceList {
+  display: grid;
+  gap: 8px;
+  margin: 14px 0 0;
+}
+
+.evidencePair {
+  display: grid;
+  grid-template-columns: minmax(140px, 180px) minmax(0, 1fr);
+  gap: 10px;
+  padding: 8px 0;
+  border-top: 1px solid var(--border);
+}
+
+.evidencePair:first-child {
+  border-top: 0;
+}
+
+.evidencePair dt {
+  font-weight: 700;
+  color: var(--muted);
+}
+
+.evidencePair dd {
+  margin: 0;
+  word-break: break-word;
+}
+
+@media (max-width: 720px) {
+  .redirectHop,
+  .evidencePair {
+    grid-template-columns: 1fr;
+  }
+
+  .redirectStep {
+    width: 32px;
+    height: 32px;
+  }
+}

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -591,3 +591,9 @@ pre {
     height: 32px;
   }
 }
+
+.suppressionCard {
+  border-color: rgba(180, 118, 27, 0.25);
+  background: linear-gradient(180deg, rgba(255, 248, 233, 0.9), rgba(255, 255, 255, 0.96));
+}
+

--- a/ui/e2e/analyze.smoke.spec.ts
+++ b/ui/e2e/analyze.smoke.spec.ts
@@ -29,7 +29,9 @@ test("runs the URL flow and exposes analyst details", async ({ page }) => {
   await page.getByRole("tab", { name: "Analyst" }).click();
   await expect(page.getByRole("heading", { name: "Contract summary" })).toBeVisible();
   await expect(page.getByText("Primary subject")).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Raw JSON" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Domain anatomy" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Evidence panel" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Raw JSON" })).toHaveCount(0);
 });
 
 test("runs the email-header flow from the same workspace", async ({ page }) => {
@@ -46,6 +48,10 @@ test("runs the email-header flow from the same workspace", async ({ page }) => {
   await expect(page.getByText("Recommended next step")).toBeVisible();
   await expect(page.getByText("Subject: smoke-email")).toBeVisible();
   await expect(page.getByText("Flow: analyze")).toBeVisible();
+
+  await page.getByRole("tab", { name: "Analyst" }).click();
+  await expect(page.getByRole("heading", { name: "Raw JSON" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Domain anatomy" })).toHaveCount(0);
 });
 
 test("surfaces structured QR upload errors from the unified page", async ({ page }) => {
@@ -59,4 +65,3 @@ test("surfaces structured QR upload errors from the unified page", async ({ page
   ).toBeVisible();
   await expect(page.getByText("Latest endpoint: POST /api/v1/qr/scan")).toBeVisible();
 });
-

--- a/ui/e2e/analyze.verdict.spec.ts
+++ b/ui/e2e/analyze.verdict.spec.ts
@@ -50,7 +50,8 @@ const SAFE_URL_RESPONSE = {
         normalization_notes: []
       },
       evidence_rows: [],
-      redirect_trace: null
+      redirect_trace: null,
+      suppression_trace: null
     }
   }
 } as const;
@@ -142,36 +143,58 @@ const ANALYST_URL_RESPONSE = {
         {
           module: "url_structure",
           category: "URL002_DECEPTIVE_SUBDOMAIN",
+          finding_key: "url_structure:URL002_DECEPTIVE_SUBDOMAIN",
+          compare_key: "url_structure:URL002_DECEPTIVE_SUBDOMAIN",
+          sort_index: 0,
           severity: "HIGH",
           confidence: "HIGH",
           cumulative_risk_score: 65,
+          risk_delta: null,
           title: "Suspicious brand token appears in a subdomain",
           explanation: "A known brand token appears outside the registrable domain.",
           family_explanation: "This link places a familiar site name in the wrong part of the address.",
           recommendations: ["Verify the destination through a trusted bookmark."],
           evidence: [
-            { label: "Hostname", value: "login.example.test" },
-            { label: "Registrable Domain", value: "example.test" }
-          ]
+            { key: "hostname", label: "Hostname", value: "login.example.test" },
+            { key: "registrable_domain", label: "Registrable Domain", value: "example.test" }
+          ],
+          evidence_map: {
+            hostname: "login.example.test",
+            registrable_domain: "example.test"
+          }
         },
         {
           module: "redirect",
           category: "RED002_CROSS_DOMAIN_REDIRECT",
+          finding_key: "redirect:RED002_CROSS_DOMAIN_REDIRECT",
+          compare_key: "redirect:RED002_CROSS_DOMAIN_REDIRECT",
+          sort_index: 1,
           severity: "INFO",
           confidence: "MEDIUM",
           cumulative_risk_score: 40,
+          risk_delta: null,
           title: "Redirect chain changes registrable domain",
           explanation: "The redirect chain moves across different registrable domains.",
           family_explanation: "This link starts on one site name and ends on a different site name.",
           recommendations: ["Verify that the final site name is expected and trusted."],
           evidence: [
             {
+              key: "chain",
               label: "Chain",
               value:
                 "https://login.example.test -> https://redirect.gateway.test -> https://final.example.org"
             },
-            { label: "Domain Path", value: "example.test -> gateway.test -> example.org" }
-          ]
+            {
+              key: "domain_path",
+              label: "Domain Path",
+              value: "example.test -> gateway.test -> example.org"
+            }
+          ],
+          evidence_map: {
+            chain:
+              "https://login.example.test -> https://redirect.gateway.test -> https://final.example.org",
+            domain_path: "example.test -> gateway.test -> example.org"
+          }
         }
       ],
       redirect_trace: {
@@ -201,6 +224,9 @@ const ANALYST_URL_RESPONSE = {
           {
             module: "url_structure",
             category: "URL003_NESTED_URL_PARAMETER",
+            finding_key: "url_structure:URL003_NESTED_URL_PARAMETER",
+            compare_key: "url_structure:URL003_NESTED_URL_PARAMETER:category:url",
+            sort_index: 0,
             hostname: "login.example.test",
             matched_allowlist_domain: "example.test",
             suppression_scope: "category",

--- a/ui/e2e/analyze.verdict.spec.ts
+++ b/ui/e2e/analyze.verdict.spec.ts
@@ -29,6 +29,167 @@ const SAFE_URL_RESPONSE = {
       signal_confidence: null,
       reasons: [],
       recommendations: []
+    },
+    analyst: {
+      domain_anatomy: {
+        submitted_url: "https://example.com",
+        canonical_url: "https://example.com/",
+        hostname: "example.com",
+        canonical_hostname: "example.com",
+        registrable_domain: "example.com",
+        canonical_registrable_domain: "example.com",
+        subdomain_labels: [],
+        registrable_labels: ["example", "com"],
+        idna_ascii_hostname: "example.com",
+        idna_unicode_hostname: "example.com",
+        is_ip_literal: false,
+        ip_literal: null,
+        obfuscated_ipv4: null,
+        obfuscated_ipv4_notes: [],
+        ipv6_mapped_ipv4: null,
+        normalization_notes: []
+      },
+      evidence_rows: [],
+      redirect_trace: null
+    }
+  }
+} as const;
+
+const ANALYST_URL_RESPONSE = {
+  schema_version: "2.0",
+  flow: "analyze",
+  mode: "single",
+  input_type: "url",
+  item_count: 1,
+  item: {
+    subject: "https://login.example.test",
+    result: {
+      input: {
+        input_type: "url",
+        content: "https://login.example.test",
+        metadata: { network_enabled: true }
+      },
+      findings: [
+        {
+          module: "url_structure",
+          category: "URL002_DECEPTIVE_SUBDOMAIN",
+          severity: "HIGH",
+          confidence: "HIGH",
+          risk_score: 65,
+          title: "Suspicious brand token appears in a subdomain",
+          explanation: "A known brand token appears outside the registrable domain.",
+          family_explanation: "This link places a familiar site name in the wrong part of the address.",
+          evidence: [
+            { label: "Hostname", value: "login.example.test" },
+            { label: "Registrable Domain", value: "example.test" }
+          ],
+          recommendations: ["Verify the destination through a trusted bookmark."]
+        },
+        {
+          module: "redirect",
+          category: "RED002_CROSS_DOMAIN_REDIRECT",
+          severity: "INFO",
+          confidence: "MEDIUM",
+          risk_score: 40,
+          title: "Redirect chain changes registrable domain",
+          explanation: "The redirect chain moves across different registrable domains.",
+          family_explanation: "This link starts on one site name and ends on a different site name.",
+          evidence: [
+            {
+              label: "Chain",
+              value:
+                "https://login.example.test -> https://redirect.gateway.test -> https://final.example.org"
+            },
+            { label: "Domain Path", value: "example.test -> gateway.test -> example.org" },
+            { label: "Redirect Hops", value: "2" }
+          ],
+          recommendations: ["Verify that the final site name is expected and trusted."]
+        }
+      ],
+      overall_risk: 65,
+      overall_severity: "HIGH",
+      summary: "Strong warning signs were found in this destination.",
+      analyzed_at: "2026-03-06T00:00:00Z"
+    },
+    family: {
+      risk_score: 65,
+      severity: "HIGH",
+      summary: "Strong warning signs were found in this destination.",
+      signal_confidence: "HIGH",
+      reasons: ["This link places a familiar site name in the wrong part of the address."],
+      recommendations: ["Verify the destination through a trusted bookmark."]
+    },
+    analyst: {
+      domain_anatomy: {
+        submitted_url: "https://login.example.test",
+        canonical_url: "https://login.example.test/",
+        hostname: "login.example.test",
+        canonical_hostname: "login.example.test",
+        registrable_domain: "example.test",
+        canonical_registrable_domain: "example.test",
+        subdomain_labels: ["login"],
+        registrable_labels: ["example", "test"],
+        idna_ascii_hostname: "login.example.test",
+        idna_unicode_hostname: "login.example.test",
+        is_ip_literal: false,
+        ip_literal: null,
+        obfuscated_ipv4: null,
+        obfuscated_ipv4_notes: [],
+        ipv6_mapped_ipv4: null,
+        normalization_notes: []
+      },
+      evidence_rows: [
+        {
+          module: "url_structure",
+          category: "URL002_DECEPTIVE_SUBDOMAIN",
+          severity: "HIGH",
+          confidence: "HIGH",
+          cumulative_risk_score: 65,
+          title: "Suspicious brand token appears in a subdomain",
+          explanation: "A known brand token appears outside the registrable domain.",
+          family_explanation: "This link places a familiar site name in the wrong part of the address.",
+          recommendations: ["Verify the destination through a trusted bookmark."],
+          evidence: [
+            { label: "Hostname", value: "login.example.test" },
+            { label: "Registrable Domain", value: "example.test" }
+          ]
+        },
+        {
+          module: "redirect",
+          category: "RED002_CROSS_DOMAIN_REDIRECT",
+          severity: "INFO",
+          confidence: "MEDIUM",
+          cumulative_risk_score: 40,
+          title: "Redirect chain changes registrable domain",
+          explanation: "The redirect chain moves across different registrable domains.",
+          family_explanation: "This link starts on one site name and ends on a different site name.",
+          recommendations: ["Verify that the final site name is expected and trusted."],
+          evidence: [
+            {
+              label: "Chain",
+              value:
+                "https://login.example.test -> https://redirect.gateway.test -> https://final.example.org"
+            },
+            { label: "Domain Path", value: "example.test -> gateway.test -> example.org" }
+          ]
+        }
+      ],
+      redirect_trace: {
+        hops: [
+          "https://login.example.test",
+          "https://redirect.gateway.test",
+          "https://final.example.org"
+        ],
+        start_url: "https://login.example.test",
+        final_url: "https://final.example.org",
+        registrable_domain_path: ["example.test", "gateway.test", "example.org"],
+        hop_count: 2,
+        crosses_registrable_domain: true,
+        max_hops_reached: false,
+        timed_out: false,
+        loop_target: null,
+        request_error: null
+      }
     }
   }
 } as const;
@@ -44,7 +205,8 @@ const BLOCK_EMAIL_RESPONSE = {
     result: {
       input: {
         input_type: "email_headers",
-        content: "Authentication-Results: mx; spf=fail; dkim=fail; dmarc=fail"
+        content: "Authentication-Results: mx; spf=fail; dkim=fail; dmarc=fail",
+        metadata: {}
       },
       findings: [
         {
@@ -127,12 +289,36 @@ test("quick mode presents a safe decision without analyst-only details", async (
       "Proceed only if you expected this item, and use trusted bookmarks for sensitive accounts."
     )
   ).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Domain anatomy" })).toHaveCount(0);
   await expect(page.getByRole("heading", { name: "Raw JSON" })).toHaveCount(0);
 });
 
-test("quick mode rewrites technical email outcomes into plain-language decisions", async ({
-  page
-}) => {
+test("analyst mode renders URL-specific panels from structured v2 payloads", async ({ page }) => {
+  await page.route("**/api/v2/analyze", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(ANALYST_URL_RESPONSE)
+    });
+  });
+
+  await gotoAnalyze(page);
+  await page.getByPlaceholder("https://example.com").fill("https://login.example.test");
+  await page.getByRole("button", { name: "Analyze URL" }).click();
+  await page.getByRole("tab", { name: "Analyst" }).click();
+
+  await expect(page.getByRole("heading", { name: "Contract summary" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Domain anatomy" })).toBeVisible();
+  await expect(page.getByText("login.example.test")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Redirect path" })).toBeVisible();
+  await expect(page.getByText("Cross-domain redirect")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Evidence panel" })).toBeVisible();
+  await expect(page.getByText("Suspicious brand token appears in a subdomain")).toBeVisible();
+  await expect(page.getByRole("button", { name: "redirect" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Raw JSON" })).toHaveCount(0);
+});
+
+test("analyst mode keeps email on the raw-details fallback", async ({ page }) => {
   await page.route("**/api/v2/analyze", async (route) => {
     await route.fulfill({
       status: 200,
@@ -150,22 +336,8 @@ test("quick mode rewrites technical email outcomes into plain-language decisions
   await page.getByRole("button", { name: "Analyze email headers" }).click();
 
   await expect(page.getByText("Action: Block")).toBeVisible();
-  await expect(page.getByText("Block and report")).toBeVisible();
-  await expect(
-    page.getByText("This message failed key trust checks and should be treated as suspicious.")
-  ).toBeVisible();
-  await expect(
-    page.getByText(
-      "The sender domain did not match its own policy, which is a strong warning sign."
-    )
-  ).toBeVisible();
-  await expect(
-    page.getByText("The message signature check failed, which can mean spoofing or tampering.")
-  ).toBeVisible();
-  await expect(
-    page.getByText("Do not follow sensitive requests until you verify them another way.")
-  ).toBeVisible();
-  await expect(
-    page.getByText("Treat this message as suspicious until you verify it another way.")
-  ).toBeVisible();
+  await page.getByRole("tab", { name: "Analyst" }).click();
+  await expect(page.getByRole("heading", { name: "Contract summary" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Raw JSON" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Domain anatomy" })).toHaveCount(0);
 });

--- a/ui/e2e/analyze.verdict.spec.ts
+++ b/ui/e2e/analyze.verdict.spec.ts
@@ -189,6 +189,26 @@ const ANALYST_URL_RESPONSE = {
         timed_out: false,
         loop_target: null,
         request_error: null
+      },
+      suppression_trace: {
+        hostname: "login.example.test",
+        configured_allowlist_domains: ["example.test"],
+        configured_allowlist_categories: ["URL"],
+        configured_allowlist_findings: [],
+        matched_allowlist_domains: ["example.test"],
+        suppressed_count: 1,
+        suppressed_rows: [
+          {
+            module: "url_structure",
+            category: "URL003_NESTED_URL_PARAMETER",
+            hostname: "login.example.test",
+            matched_allowlist_domain: "example.test",
+            suppression_scope: "category",
+            matched_rule: "URL",
+            reason:
+              "Suppressed because the hostname matched an allowlist domain and category prefix URL was enabled."
+          }
+        ]
       }
     }
   }
@@ -312,6 +332,8 @@ test("analyst mode renders URL-specific panels from structured v2 payloads", asy
   await expect(page.getByText("login.example.test")).toBeVisible();
   await expect(page.getByRole("heading", { name: "Redirect path" })).toBeVisible();
   await expect(page.getByText("Cross-domain redirect")).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Suppression trace" })).toBeVisible();
+  await expect(page.getByText("Suppressed: 1")).toBeVisible();
   await expect(page.getByRole("heading", { name: "Evidence panel" })).toBeVisible();
   await expect(page.getByText("Suspicious brand token appears in a subdomain")).toBeVisible();
   await expect(page.getByRole("button", { name: "redirect" })).toBeVisible();

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -10,6 +10,7 @@ export interface ApiErrorEnvelope {
 }
 
 export interface ApiEvidence {
+  key: string;
   label: string;
   value: string;
 }
@@ -52,14 +53,19 @@ export interface ApiFamilyPayload {
 export interface ApiAnalystEvidenceRow {
   module: string;
   category: string;
+  finding_key: string;
+  compare_key: string;
+  sort_index: number;
   severity: string;
   confidence: string;
   cumulative_risk_score: number;
+  risk_delta: number | null;
   title: string;
   explanation: string;
   family_explanation: string;
   recommendations: string[];
   evidence: ApiEvidence[];
+  evidence_map: Record<string, string>;
 }
 
 export interface ApiDomainAnatomy {
@@ -97,6 +103,9 @@ export interface ApiRedirectTrace {
 export interface ApiSuppressionTraceRow {
   module: string;
   category: string;
+  finding_key: string;
+  compare_key: string;
+  sort_index: number;
   hostname: string;
   matched_allowlist_domain: string;
   suppression_scope: "category" | "finding";

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -94,10 +94,31 @@ export interface ApiRedirectTrace {
   request_error: string | null;
 }
 
+export interface ApiSuppressionTraceRow {
+  module: string;
+  category: string;
+  hostname: string;
+  matched_allowlist_domain: string;
+  suppression_scope: "category" | "finding";
+  matched_rule: string;
+  reason: string;
+}
+
+export interface ApiSuppressionTrace {
+  hostname: string | null;
+  configured_allowlist_domains: string[];
+  configured_allowlist_categories: string[];
+  configured_allowlist_findings: string[];
+  matched_allowlist_domains: string[];
+  suppressed_count: number;
+  suppressed_rows: ApiSuppressionTraceRow[];
+}
+
 export interface ApiUrlAnalystPayload {
   domain_anatomy: ApiDomainAnatomy;
   evidence_rows: ApiAnalystEvidenceRow[];
   redirect_trace?: ApiRedirectTrace | null;
+  suppression_trace?: ApiSuppressionTrace | null;
 }
 
 export interface ApiItem {

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -9,17 +9,102 @@ export interface ApiErrorEnvelope {
   };
 }
 
+export interface ApiEvidence {
+  label: string;
+  value: string;
+}
+
+export interface ApiFinding {
+  module: string;
+  category: string;
+  severity: string;
+  confidence: string;
+  risk_score: number;
+  title: string;
+  explanation: string;
+  family_explanation: string;
+  evidence: ApiEvidence[];
+  recommendations: string[];
+}
+
+export interface ApiAnalysisResult {
+  input: {
+    input_type: string;
+    content: string;
+    metadata: Record<string, unknown>;
+  };
+  findings: ApiFinding[];
+  overall_risk: number;
+  overall_severity: string;
+  summary: string;
+  analyzed_at: string;
+}
+
+export interface ApiFamilyPayload {
+  risk_score: number;
+  severity: string;
+  summary: string;
+  signal_confidence: string | null;
+  reasons: string[];
+  recommendations: string[];
+}
+
+export interface ApiAnalystEvidenceRow {
+  module: string;
+  category: string;
+  severity: string;
+  confidence: string;
+  cumulative_risk_score: number;
+  title: string;
+  explanation: string;
+  family_explanation: string;
+  recommendations: string[];
+  evidence: ApiEvidence[];
+}
+
+export interface ApiDomainAnatomy {
+  submitted_url: string;
+  canonical_url: string;
+  hostname: string | null;
+  canonical_hostname: string | null;
+  registrable_domain: string | null;
+  canonical_registrable_domain: string | null;
+  subdomain_labels: string[];
+  registrable_labels: string[];
+  idna_ascii_hostname: string | null;
+  idna_unicode_hostname: string | null;
+  is_ip_literal: boolean;
+  ip_literal: string | null;
+  obfuscated_ipv4: string | null;
+  obfuscated_ipv4_notes: string[];
+  ipv6_mapped_ipv4: string | null;
+  normalization_notes: string[];
+}
+
+export interface ApiRedirectTrace {
+  hops: string[];
+  start_url: string;
+  final_url: string;
+  registrable_domain_path: string[];
+  hop_count: number;
+  crosses_registrable_domain: boolean;
+  max_hops_reached: boolean;
+  timed_out: boolean;
+  loop_target: string | null;
+  request_error: string | null;
+}
+
+export interface ApiUrlAnalystPayload {
+  domain_anatomy: ApiDomainAnatomy;
+  evidence_rows: ApiAnalystEvidenceRow[];
+  redirect_trace?: ApiRedirectTrace | null;
+}
+
 export interface ApiItem {
   subject: string;
-  result: Record<string, unknown>;
-  family?: {
-    risk_score: number;
-    severity: string;
-    summary: string;
-    signal_confidence: string | null;
-    reasons: string[];
-    recommendations: string[];
-  };
+  result: ApiAnalysisResult;
+  family?: ApiFamilyPayload;
+  analyst?: ApiUrlAnalystPayload;
 }
 
 export type AnalyzeV2InputType = "url" | "email_headers" | "email_file";
@@ -136,4 +221,3 @@ export function getPrimaryItem(response: ApiWrappedResponse): ApiItem | null {
 export function asPrettyJson(value: unknown): string {
   return JSON.stringify(value, null, 2);
 }
-


### PR DESCRIPTION
## Summary
Adds the first URL-focused Analyst Mode slice for V2.

- extends /api/v2/analyze with additive URL-only item.analyst fields
- adds structured domain anatomy, evidence rows, and redirect trace payloads
- refactors /analyze into a smaller page shell with extracted result panels
- keeps email and QR on the existing analyst fallback
- updates contract tests, snapshot fixtures, and Playwright specs

## Verification
- python -m pytest -q
- 
pm run lint
- 
pm run build

## Notes
- Local Playwright/browser execution was blocked in the sandbox by Windows spawn EPERM, so CI should be treated as the browser validation source for this branch.