### PR TITLE
Add policy pack data model, storage, and resolver (E5-I1)

### DIFF
--- a/src/lsh/application/policy_resolver.py
+++ b/src/lsh/application/policy_resolver.py
@@ -1,0 +1,76 @@
+"""Resolve policy packs into analysis metadata.
+
+Merges a stored policy pack's suppression rules with inline allowlist
+parameters using union semantics.  Inline params continue to work
+independently; policy packs are additive.
+"""
+
+from __future__ import annotations
+
+from lsh.core.policy import PolicyPack
+
+
+def resolve_metadata_with_policy(
+    metadata: dict[str, object],
+    policy: PolicyPack | None,
+    *,
+    input_type: str = "url",
+) -> dict[str, object]:
+    """Merge a policy pack's rules into existing request metadata.
+
+    Returns a new dict (does not mutate *metadata*).
+
+    Rules:
+    - If *policy* is ``None`` or disabled, return *metadata* unchanged.
+    - If *input_type* is not in ``policy.input_types``, return unchanged.
+    - Otherwise union each allowlist axis (domains, categories, findings)
+      and tag the merged dict with policy provenance metadata.
+    """
+    if policy is None or not policy.enabled:
+        return metadata
+
+    if input_type not in policy.input_types:
+        return metadata
+
+    merged: dict[str, object] = dict(metadata)
+
+    merged["allowlist_domains"] = _union_str_lists(
+        merged.get("allowlist_domains"), policy.allowlist_domains
+    )
+    merged["allowlist_categories"] = _union_str_lists(
+        merged.get("allowlist_categories"), policy.allowlist_categories
+    )
+    merged["allowlist_findings"] = _union_str_lists(
+        merged.get("allowlist_findings"), policy.allowlist_findings
+    )
+
+    # Provenance tags for audit/trace visibility
+    merged["_applied_policy_id"] = policy.id
+    merged["_applied_policy_name"] = policy.name
+
+    return merged
+
+
+def _union_str_lists(
+    existing: object, additions: list[str]
+) -> list[str]:
+    """Union two string lists, deduplicating while preserving order."""
+    base = _to_str_list(existing)
+    seen: set[str] = set(base)
+    result = list(base)
+    for item in additions:
+        if item not in seen:
+            seen.add(item)
+            result.append(item)
+    return result
+
+
+def _to_str_list(value: object) -> list[str]:
+    """Coerce a value to a list of strings."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return [item for item in value if isinstance(item, str)]
+    if isinstance(value, str):
+        return [part.strip() for part in value.split(",") if part.strip()]
+    return []

--- a/src/lsh/core/policy.py
+++ b/src/lsh/core/policy.py
@@ -1,0 +1,36 @@
+"""Policy pack data model for persisted suppression configurations."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class PolicyPack(BaseModel):
+    """A named, persisted suppression policy.
+
+    Captures the same three suppression axes as inline allowlist params
+    (domains, categories, findings) plus metadata for identity and lifecycle.
+    """
+
+    id: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    name: str = Field(min_length=1, max_length=120)
+    description: str = ""
+
+    # Suppression rules (same keys as AnalysisInput.metadata allowlist params)
+    allowlist_domains: list[str] = Field(default_factory=list)
+    allowlist_categories: list[str] = Field(default_factory=list)
+    allowlist_findings: list[str] = Field(default_factory=list)
+
+    # Scoping: which input types this policy applies to
+    input_types: list[Literal["url", "email_headers", "email_file"]] = Field(
+        default=["url"],
+    )
+
+    enabled: bool = True
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    tags: list[str] = Field(default_factory=list)

--- a/src/lsh/core/policy_store.py
+++ b/src/lsh/core/policy_store.py
@@ -1,0 +1,97 @@
+"""File-based JSON storage for policy packs."""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import UTC, datetime
+from pathlib import Path
+
+from lsh.core.policy import PolicyPack
+
+_DEFAULT_STORE_DIR = ".lsh"
+_POLICY_FILE = "policies.json"
+_LSH_STORE_DIR_ENV = "LSH_POLICY_STORE_DIR"
+
+
+class PolicyStore:
+    """CRUD operations for policy packs backed by a single JSON file.
+
+    Storage layout::
+
+        <store_dir>/policies.json   # JSON array of serialized PolicyPack objects
+
+    The store directory defaults to ``.lsh/`` in the working directory and can
+    be overridden via the ``LSH_POLICY_STORE_DIR`` environment variable or the
+    ``store_dir`` constructor argument.
+    """
+
+    def __init__(self, store_dir: str | None = None) -> None:
+        env_dir = os.getenv(_LSH_STORE_DIR_ENV)
+        self._store_dir = Path(store_dir or env_dir or _DEFAULT_STORE_DIR)
+        self._file_path = self._store_dir / _POLICY_FILE
+
+    @property
+    def file_path(self) -> Path:
+        return self._file_path
+
+    def _read_all_raw(self) -> list[dict[str, object]]:
+        if not self._file_path.exists():
+            return []
+        with open(self._file_path, encoding="utf-8") as f:
+            data = json.load(f)
+        if not isinstance(data, list):
+            return []
+        return data
+
+    def _write_all_raw(self, policies: list[dict[str, object]]) -> None:
+        self._store_dir.mkdir(parents=True, exist_ok=True)
+        with open(self._file_path, "w", encoding="utf-8") as f:
+            json.dump(policies, f, indent=2, default=str)
+
+    def list_policies(self) -> list[PolicyPack]:
+        """Return all stored policy packs."""
+        return [PolicyPack.model_validate(item) for item in self._read_all_raw()]
+
+    def get_policy(self, policy_id: str) -> PolicyPack | None:
+        """Return a single policy pack by ID, or ``None`` if not found."""
+        for item in self._read_all_raw():
+            if item.get("id") == policy_id:
+                return PolicyPack.model_validate(item)
+        return None
+
+    def create_policy(self, policy: PolicyPack) -> PolicyPack:
+        """Persist a new policy pack and return it."""
+        all_data = self._read_all_raw()
+        all_data.append(json.loads(policy.model_dump_json()))
+        self._write_all_raw(all_data)
+        return policy
+
+    def update_policy(
+        self, policy_id: str, updates: dict[str, object]
+    ) -> PolicyPack | None:
+        """Apply partial updates to an existing policy pack.
+
+        Returns the updated policy, or ``None`` if the ID was not found.
+        Protected fields (``id``, ``created_at``) cannot be changed.
+        """
+        all_data = self._read_all_raw()
+        for i, item in enumerate(all_data):
+            if item.get("id") == policy_id:
+                for key, value in updates.items():
+                    if key not in ("id", "created_at"):
+                        item[key] = value
+                item["updated_at"] = datetime.now(UTC).isoformat()
+                all_data[i] = item
+                self._write_all_raw(all_data)
+                return PolicyPack.model_validate(item)
+        return None
+
+    def delete_policy(self, policy_id: str) -> bool:
+        """Delete a policy pack by ID. Returns ``True`` if found and removed."""
+        all_data = self._read_all_raw()
+        filtered = [item for item in all_data if item.get("id") != policy_id]
+        if len(filtered) == len(all_data):
+            return False
+        self._write_all_raw(filtered)
+        return True

--- a/tests/application/test_policy_resolver.py
+++ b/tests/application/test_policy_resolver.py
@@ -1,0 +1,133 @@
+"""Tests for policy pack metadata resolution."""
+
+from __future__ import annotations
+
+from lsh.application.policy_resolver import resolve_metadata_with_policy
+from lsh.core.policy import PolicyPack
+
+
+def _policy(**kwargs: object) -> PolicyPack:
+    defaults: dict[str, object] = {"name": "test-policy"}
+    defaults.update(kwargs)
+    return PolicyPack(**defaults)
+
+
+def test_none_policy_returns_metadata_unchanged() -> None:
+    metadata: dict[str, object] = {"allowlist_domains": ["a.com"]}
+    result = resolve_metadata_with_policy(metadata, None)
+    assert result is metadata  # same object, not copied
+
+
+def test_disabled_policy_returns_metadata_unchanged() -> None:
+    policy = _policy(enabled=False, allowlist_domains=["b.com"])
+    metadata: dict[str, object] = {"allowlist_domains": ["a.com"]}
+    result = resolve_metadata_with_policy(metadata, policy)
+    assert result is metadata
+
+
+def test_input_type_mismatch_returns_unchanged() -> None:
+    policy = _policy(input_types=["email_headers"], allowlist_domains=["b.com"])
+    metadata: dict[str, object] = {}
+    result = resolve_metadata_with_policy(metadata, policy, input_type="url")
+    assert result is metadata
+
+
+def test_unions_domains() -> None:
+    policy = _policy(allowlist_domains=["b.com", "c.com"])
+    metadata: dict[str, object] = {"allowlist_domains": ["a.com", "b.com"]}
+    result = resolve_metadata_with_policy(metadata, policy)
+    domains = result["allowlist_domains"]
+    assert isinstance(domains, list)
+    assert set(domains) == {"a.com", "b.com", "c.com"}
+
+
+def test_unions_categories() -> None:
+    policy = _policy(allowlist_categories=["URL", "NET"])
+    metadata: dict[str, object] = {"allowlist_categories": ["HMG"]}
+    result = resolve_metadata_with_policy(metadata, policy)
+    cats = result["allowlist_categories"]
+    assert isinstance(cats, list)
+    assert set(cats) == {"HMG", "URL", "NET"}
+
+
+def test_unions_findings() -> None:
+    policy = _policy(allowlist_findings=["HMG002_PUNYCODE_VISIBILITY"])
+    metadata: dict[str, object] = {"allowlist_findings": ["URL001"]}
+    result = resolve_metadata_with_policy(metadata, policy)
+    findings = result["allowlist_findings"]
+    assert isinstance(findings, list)
+    assert set(findings) == {"URL001", "HMG002_PUNYCODE_VISIBILITY"}
+
+
+def test_empty_metadata_gets_policy_values() -> None:
+    policy = _policy(
+        allowlist_domains=["trusted.com"],
+        allowlist_categories=["ALL"],
+        allowlist_findings=["NET001"],
+    )
+    result = resolve_metadata_with_policy({}, policy)
+    assert result["allowlist_domains"] == ["trusted.com"]
+    assert result["allowlist_categories"] == ["ALL"]
+    assert result["allowlist_findings"] == ["NET001"]
+
+
+def test_does_not_mutate_original_metadata() -> None:
+    policy = _policy(allowlist_domains=["new.com"])
+    original: dict[str, object] = {"allowlist_domains": ["old.com"]}
+    result = resolve_metadata_with_policy(original, policy)
+    assert result is not original
+    assert original["allowlist_domains"] == ["old.com"]  # not mutated
+
+
+def test_tags_provenance_metadata() -> None:
+    policy = _policy()
+    result = resolve_metadata_with_policy({}, policy)
+    assert result["_applied_policy_id"] == policy.id
+    assert result["_applied_policy_name"] == policy.name
+
+
+def test_preserves_non_allowlist_metadata() -> None:
+    policy = _policy(allowlist_domains=["x.com"])
+    metadata: dict[str, object] = {
+        "network_enabled": True,
+        "network_max_hops": 10,
+        "custom_field": "keep",
+    }
+    result = resolve_metadata_with_policy(metadata, policy)
+    assert result["network_enabled"] is True
+    assert result["network_max_hops"] == 10
+    assert result["custom_field"] == "keep"
+
+
+def test_email_input_type_scoping() -> None:
+    policy = _policy(
+        input_types=["url", "email_headers"],
+        allowlist_domains=["mail.example.com"],
+    )
+    # Should apply to email_headers
+    result = resolve_metadata_with_policy({}, policy, input_type="email_headers")
+    assert result["allowlist_domains"] == ["mail.example.com"]
+
+    # Should NOT apply to email_file (not in input_types)
+    result2 = resolve_metadata_with_policy({}, policy, input_type="email_file")
+    assert result2 == {}
+
+
+def test_csv_string_metadata_coercion() -> None:
+    """Metadata values that are CSV strings should be parsed correctly."""
+    policy = _policy(allowlist_domains=["new.com"])
+    metadata: dict[str, object] = {"allowlist_domains": "old.com, legacy.com"}
+    result = resolve_metadata_with_policy(metadata, policy)
+    domains = result["allowlist_domains"]
+    assert isinstance(domains, list)
+    assert set(domains) == {"old.com", "legacy.com", "new.com"}
+
+
+def test_deduplication_preserves_order() -> None:
+    policy = _policy(allowlist_domains=["c.com", "a.com"])
+    metadata: dict[str, object] = {"allowlist_domains": ["a.com", "b.com"]}
+    result = resolve_metadata_with_policy(metadata, policy)
+    domains = result["allowlist_domains"]
+    assert isinstance(domains, list)
+    # Original order preserved, then new additions
+    assert domains == ["a.com", "b.com", "c.com"]

--- a/tests/core/test_policy.py
+++ b/tests/core/test_policy.py
@@ -1,0 +1,78 @@
+"""Tests for the PolicyPack data model."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from lsh.core.policy import PolicyPack
+
+
+def test_minimal_policy_creates_with_defaults() -> None:
+    policy = PolicyPack(name="test")
+    assert policy.name == "test"
+    assert policy.description == ""
+    assert policy.allowlist_domains == []
+    assert policy.allowlist_categories == []
+    assert policy.allowlist_findings == []
+    assert policy.input_types == ["url"]
+    assert policy.enabled is True
+    assert policy.tags == []
+    assert len(policy.id) == 36  # UUID string
+
+
+def test_full_policy_round_trips_through_json() -> None:
+    policy = PolicyPack(
+        name="corp-allowlist",
+        description="Trusted corporate domains",
+        allowlist_domains=["example.com", "corp.internal"],
+        allowlist_categories=["HMG", "ASCII"],
+        allowlist_findings=["HMG002_PUNYCODE_VISIBILITY"],
+        input_types=["url", "email_headers"],
+        enabled=True,
+        tags=["production", "trusted"],
+    )
+    json_str = policy.model_dump_json()
+    restored = PolicyPack.model_validate_json(json_str)
+    assert restored.name == policy.name
+    assert restored.allowlist_domains == policy.allowlist_domains
+    assert restored.allowlist_categories == policy.allowlist_categories
+    assert restored.allowlist_findings == policy.allowlist_findings
+    assert restored.input_types == policy.input_types
+    assert restored.tags == policy.tags
+    assert restored.id == policy.id
+
+
+def test_name_too_short_raises() -> None:
+    with pytest.raises(ValidationError):
+        PolicyPack(name="")
+
+
+def test_name_too_long_raises() -> None:
+    with pytest.raises(ValidationError):
+        PolicyPack(name="x" * 121)
+
+
+def test_invalid_input_type_raises() -> None:
+    with pytest.raises(ValidationError):
+        PolicyPack(name="bad", input_types=["unknown_type"])
+
+
+def test_each_policy_gets_unique_id() -> None:
+    ids = {PolicyPack(name="a").id for _ in range(20)}
+    assert len(ids) == 20
+
+
+def test_timestamps_are_utc() -> None:
+    before = datetime.now(UTC)
+    policy = PolicyPack(name="ts-test")
+    after = datetime.now(UTC)
+    assert before <= policy.created_at <= after
+    assert before <= policy.updated_at <= after
+
+
+def test_disabled_policy() -> None:
+    policy = PolicyPack(name="disabled", enabled=False)
+    assert policy.enabled is False

--- a/tests/core/test_policy_store.py
+++ b/tests/core/test_policy_store.py
@@ -1,0 +1,179 @@
+"""Tests for the file-based PolicyStore."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from lsh.core.policy import PolicyPack
+from lsh.core.policy_store import PolicyStore
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> PolicyStore:
+    return PolicyStore(store_dir=str(tmp_path))
+
+
+def _make_policy(name: str = "test", **kwargs: object) -> PolicyPack:
+    return PolicyPack(name=name, **kwargs)
+
+
+def test_list_empty_store(store: PolicyStore) -> None:
+    assert store.list_policies() == []
+
+
+def test_create_and_list(store: PolicyStore) -> None:
+    p = _make_policy("alpha")
+    store.create_policy(p)
+    policies = store.list_policies()
+    assert len(policies) == 1
+    assert policies[0].name == "alpha"
+    assert policies[0].id == p.id
+
+
+def test_create_multiple(store: PolicyStore) -> None:
+    store.create_policy(_make_policy("one"))
+    store.create_policy(_make_policy("two"))
+    store.create_policy(_make_policy("three"))
+    assert len(store.list_policies()) == 3
+
+
+def test_get_by_id(store: PolicyStore) -> None:
+    p = _make_policy("findme")
+    store.create_policy(p)
+    found = store.get_policy(p.id)
+    assert found is not None
+    assert found.name == "findme"
+
+
+def test_get_missing_returns_none(store: PolicyStore) -> None:
+    assert store.get_policy("nonexistent-id") is None
+
+
+def test_update_changes_fields(store: PolicyStore) -> None:
+    p = _make_policy("original")
+    store.create_policy(p)
+
+    updated = store.update_policy(p.id, {"name": "renamed", "enabled": False})
+    assert updated is not None
+    assert updated.name == "renamed"
+    assert updated.enabled is False
+    assert updated.id == p.id  # ID unchanged
+    assert updated.created_at == p.created_at  # created_at protected
+
+    # Verify persistence
+    reloaded = store.get_policy(p.id)
+    assert reloaded is not None
+    assert reloaded.name == "renamed"
+
+
+def test_update_cannot_change_id(store: PolicyStore) -> None:
+    p = _make_policy("protect-id")
+    store.create_policy(p)
+    updated = store.update_policy(p.id, {"id": "new-id"})
+    assert updated is not None
+    assert updated.id == p.id  # ID preserved
+
+
+def test_update_cannot_change_created_at(store: PolicyStore) -> None:
+    p = _make_policy("protect-ts")
+    store.create_policy(p)
+    updated = store.update_policy(p.id, {"created_at": "2020-01-01T00:00:00+00:00"})
+    assert updated is not None
+    assert updated.created_at == p.created_at
+
+
+def test_update_missing_returns_none(store: PolicyStore) -> None:
+    assert store.update_policy("nonexistent", {"name": "nope"}) is None
+
+
+def test_update_sets_updated_at(store: PolicyStore) -> None:
+    p = _make_policy("ts-update")
+    store.create_policy(p)
+    original_updated = p.updated_at
+
+    updated = store.update_policy(p.id, {"description": "changed"})
+    assert updated is not None
+    assert updated.updated_at >= original_updated
+
+
+def test_delete_removes_policy(store: PolicyStore) -> None:
+    p = _make_policy("delete-me")
+    store.create_policy(p)
+    assert len(store.list_policies()) == 1
+
+    result = store.delete_policy(p.id)
+    assert result is True
+    assert len(store.list_policies()) == 0
+
+
+def test_delete_missing_returns_false(store: PolicyStore) -> None:
+    assert store.delete_policy("nonexistent") is False
+
+
+def test_delete_only_target(store: PolicyStore) -> None:
+    p1 = _make_policy("keep")
+    p2 = _make_policy("remove")
+    store.create_policy(p1)
+    store.create_policy(p2)
+
+    store.delete_policy(p2.id)
+    remaining = store.list_policies()
+    assert len(remaining) == 1
+    assert remaining[0].id == p1.id
+
+
+def test_store_creates_directory(tmp_path: Path) -> None:
+    nested = tmp_path / "deep" / "nested"
+    store = PolicyStore(store_dir=str(nested))
+    store.create_policy(_make_policy("mkdir-test"))
+    assert (nested / "policies.json").exists()
+
+
+def test_missing_file_returns_empty(store: PolicyStore) -> None:
+    """Reading from a nonexistent file should not raise."""
+    assert store.list_policies() == []
+    assert store.get_policy("any") is None
+
+
+def test_corrupted_file_non_list(store: PolicyStore) -> None:
+    """A file containing non-list JSON should return empty."""
+    store.file_path.parent.mkdir(parents=True, exist_ok=True)
+    store.file_path.write_text('{"not": "a list"}')
+    assert store.list_policies() == []
+
+
+def test_full_crud_round_trip(store: PolicyStore) -> None:
+    """End-to-end: create, read, update, list, delete."""
+    p = _make_policy(
+        "e2e",
+        allowlist_domains=["a.com"],
+        allowlist_categories=["HMG"],
+        allowlist_findings=["HMG001"],
+        tags=["test"],
+    )
+    created = store.create_policy(p)
+    assert created.name == "e2e"
+
+    fetched = store.get_policy(p.id)
+    assert fetched is not None
+    assert fetched.allowlist_domains == ["a.com"]
+
+    store.update_policy(p.id, {"allowlist_domains": ["a.com", "b.com"]})
+    updated = store.get_policy(p.id)
+    assert updated is not None
+    assert "b.com" in updated.allowlist_domains
+
+    assert len(store.list_policies()) == 1
+
+    store.delete_policy(p.id)
+    assert len(store.list_policies()) == 0
+
+
+def test_env_override(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    env_dir = tmp_path / "env-store"
+    monkeypatch.setenv("LSH_POLICY_STORE_DIR", str(env_dir))
+    store = PolicyStore()
+    store.create_policy(_make_policy("env-test"))
+    assert (env_dir / "policies.json").exists()


### PR DESCRIPTION
## Summary
- Add `PolicyPack` Pydantic model (`src/lsh/core/policy.py`) with suppression rules (domains, categories, findings), input type scoping, UUID identity, and lifecycle fields
- Add `PolicyStore` (`src/lsh/core/policy_store.py`) with file-based JSON CRUD at `.lsh/policies.json`, env-configurable via `LSH_POLICY_STORE_DIR`
- Add `resolve_metadata_with_policy()` (`src/lsh/application/policy_resolver.py`) with union-merge semantics for combining stored policy rules with inline request params
- Add 39 tests across model validation, store CRUD, and resolver merge logic

## Design
- **Local-first**: JSON file storage, no database dependency
- **Backward compatible**: Inline allowlist params continue working; policies are additive (union merge)
- **Existing flow unchanged**: `allowlist.py` internals untouched; resolution happens at service/adapter layer

## Test plan
- [x] 8 model tests (validation, defaults, round-trip, uniqueness)
- [x] 18 store tests (CRUD, protected fields, env override, corrupted file)
- [x] 13 resolver tests (merge, scoping, mutation safety, provenance)
- [x] Full suite: 266 passed, 7 skipped
- [x] ruff + mypy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)