### PR TITLE
feat(api): add v2 policy CRUD and analyze policy_id integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ cd ui && npm run lint && npm run build  # frontend
 | `POST /api/v1/url/check` | Analyze a URL for homoglyph/IDN tricks, ASCII lookalikes, suspicious structure, IP literals, and optional redirect-chain following |
 | `POST /api/v1/email/check` | Analyze raw email authentication headers (SPF/DKIM/DMARC) |
 | `POST /api/v1/qr/scan` | Upload a QR image, decode payloads, extract URLs, run URL analysis |
-| `POST /api/v2/analyze` | Unified endpoint for URL, email_headers, and email_file input types with family summaries plus URL analyst projections |
+| `POST /api/v2/analyze` | Unified endpoint for URL, email_headers, and email_file input types with family summaries plus URL analyst projections; accepts optional `policy_id` for URL policy-pack application |
+| `GET/POST /api/v2/policies` | List and create persisted policy packs |
+| `GET/PUT/DELETE /api/v2/policies/{id}` | Read, update (full/partial), and delete one policy pack |
 
 **CLI** (`lsh`): `check`, `email-check`, `qr-scan` commands with `--json`, `--family`, `--network`, and allowlist flags.
 
@@ -66,7 +68,7 @@ Implemented now:
 - Minimal FastAPI adapter in `src/lsh/adapters/api.py` (optional dependency; QR upload route degrades gracefully when `python-multipart` is missing)
 - Reusable family formatter layer in `src/lsh/formatters/family.py`
 - Reusable structured response wrappers in `src/lsh/formatters/structured.py`
-- Draft unified v2 endpoint (`POST /api/v2/analyze`) plus v1/v2 parity, analyst projections, and edge-case test coverage
+- Unified v2 endpoint (`POST /api/v2/analyze`) plus v1/v2 parity, analyst projections, policy-pack `policy_id` support, and edge-case test coverage
 - URL-focused offline modules:
   - `homoglyph` (Unicode/IDN spoofing)
   - `ascii_lookalike` (ASCII glyph and leet brand lookalikes)
@@ -97,7 +99,7 @@ In progress and next:
 
 - Hosted validation closure for Session 9 deployment checklist
 - Email/QR analyst-mode parity beyond the current URL-first slice
-- v2 policy management, persisted history/compare flows, and hardening milestones (tracked in `docs/V2_ROADMAP_ISSUES.md`)
+- Persisted history/compare flows and hardening milestones (tracked in `docs/V2_ROADMAP_ISSUES.md`)
 
 ## Quick Start
 
@@ -159,13 +161,24 @@ Optional QR legacy-key control for API integrations:
 LSH_API_INCLUDE_QR_LEGACY_KEYS=false uvicorn lsh.adapters.api:app --host 127.0.0.1 --port 8000
 ```
 
+Optional policy-store path override for persisted policy packs:
+
+```bash
+LSH_POLICY_STORE_DIR=.lsh uvicorn lsh.adapters.api:app --host 127.0.0.1 --port 8000
+```
+
 Current endpoints:
 
 - `GET /health`
 - `POST /api/v1/url/check`
 - `POST /api/v1/email/check`
 - `POST /api/v1/qr/scan` (`multipart/form-data` with uploaded file)
-- `POST /api/v2/analyze` (unified single-item analyze endpoint, draft)
+- `POST /api/v2/analyze` (unified single-item analyze endpoint; URL input accepts optional `policy_id`)
+- `GET /api/v2/policies`
+- `POST /api/v2/policies`
+- `GET /api/v2/policies/{id}`
+- `PUT /api/v2/policies/{id}`
+- `DELETE /api/v2/policies/{id}`
 
 Contract and integration notes: `docs/API_INTEGRATION.md`
 
@@ -207,7 +220,7 @@ NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:8000 NEXT_PUBLIC_UI_ORIGIN=http://127.
 NEXT_PUBLIC_API_BASE_URL=http://127.0.0.1:8000 NEXT_PUBLIC_UI_ORIGIN=http://127.0.0.1:3000 npm run smoke:e2e
 ```
 
-Roadmap note: the current `ui/` app is a contract-validation surface, not the final product UX.  
+Roadmap note: the current `ui/` app is a contract-validation surface, not the final product UX.
 The full v2 experience plan lives in `docs/V2_BLUEPRINT.md`.
 
 ### Quick Smoke Examples

--- a/SESSION_LOG.md
+++ b/SESSION_LOG.md
@@ -2367,3 +2367,51 @@ Development session history. Each entry documents what was done, why, and what's
 - `npm run build`
 - `gh pr checks 13 --watch`
 
+
+---
+
+## 2026-03-11 - Session 15A: E5 backend policy CRUD + analyze policy integration
+
+**Agent:** Codex
+
+**Branch:** `feat/e5-policy-pack-model`
+
+**Goal:** Ship E5 backend slice: add `/api/v2/policies` CRUD, add `policy_id` support on `/api/v2/analyze`, keep v1 untouched, and close with tests/docs.
+
+**Module(s) Touched:** FastAPI adapter, typed API models, application policy service seam, adapter tests, README/API integration docs
+
+**Changes:**
+- Added v2 policy CRUD routes:
+  - `GET /api/v2/policies`
+  - `GET /api/v2/policies/{id}`
+  - `POST /api/v2/policies`
+  - `PUT /api/v2/policies/{id}`
+  - `DELETE /api/v2/policies/{id}`
+- Added typed policy request/response models and OpenAPI coverage for new routes.
+- Added app-layer `PolicyService` wrapper so adapter does not manage store details directly.
+- Extended `AnalyzeRequestV2` with optional `policy_id`.
+- Wired analyze URL flow to load policy by `policy_id`, return structured `404` (`POLICY_NOT_FOUND`) when missing, and merge policy + inline metadata via `resolve_metadata_with_policy(...)`.
+- Preserved existing behavior when `policy_id` is omitted and kept v1 endpoints unchanged.
+- Added adapter tests for policy CRUD success/error/validation paths and analyze policy integration/union behavior.
+- Updated docs for new endpoints, `policy_id`, and `LSH_POLICY_STORE_DIR` behavior.
+
+**Decisions:**
+- Kept structured explicit API errors in the existing envelope style (`detail.schema_version = "1.0"`) to avoid contract breakage.
+- Used deterministic delete response (`{id, deleted}`) instead of 404-on-delete-miss.
+- Deferred line-ending normalization policy (`.gitattributes`) to a separate cleanup change; current CRLF/LF warnings are non-blocking.
+
+**Open Questions:**
+- Do we want follow-up coverage for concurrent policy writes on the JSON store path, or keep that for later persistence hardening?
+
+**Next:**
+- Commit and push this slice.
+- Optionally open a small follow-up PR for `.gitattributes` line-ending normalization policy.
+
+**Tests / Verification:**
+- `python -m pytest tests/core/test_policy.py tests/core/test_policy_store.py tests/application/test_policy_resolver.py -q` passed (`39 passed`).
+- `python -m pytest tests/adapters/test_api.py -q` passed (`32 passed, 7 skipped`).
+- `python -m pytest tests/contracts/test_v1_v2_snapshot_parity.py -q` passed (`3 passed`).
+- `python -m pytest -q` passed (`275 passed, 7 skipped`).
+- `python -m ruff check src tests` passed.
+- `python -m mypy src` passed.
+- `git diff --check` clean (no whitespace/check failures).

--- a/docs/API_INTEGRATION.md
+++ b/docs/API_INTEGRATION.md
@@ -2,9 +2,9 @@
 
 ## Status
 
-Current stable contract: `1.0` (`/api/v1/*`)  
-Current draft contract: `2.0` (`/api/v2/analyze`)  
-Updated: `2026-03-08` (E4 analyst-mode compare-ready contract update)
+Current stable contract: `1.0` (`/api/v1/*`)
+Current draft contract: `2.0` (`/api/v2/analyze`, `/api/v2/policies`)
+Updated: `2026-03-11` (E5 policy CRUD + analyze policy-id integration)
 
 This document is the integration source of truth for backend consumers (Next.js UI, scripts, and service callers).
 
@@ -23,6 +23,11 @@ Endpoints:
 - `POST /api/v1/email/check`
 - `POST /api/v1/qr/scan`
 - `POST /api/v2/analyze` (draft v2 unified endpoint)
+- `GET /api/v2/policies`
+- `POST /api/v2/policies`
+- `GET /api/v2/policies/{id}`
+- `PUT /api/v2/policies/{id}`
+- `DELETE /api/v2/policies/{id}`
 
 ## CORS Contract
 
@@ -48,6 +53,7 @@ LSH_API_CORS_ALLOW_ORIGINS=https://safe-link-ui.example.com
   "content": "https://example.com",
   "subject": "optional display label",
   "family": false,
+  "policy_id": "optional-policy-id",
   "allowlist_domains": ["trusted.example"],
   "allowlist_categories": ["HMG", "ASCII"],
   "allowlist_findings": ["HMG002_PUNYCODE_VISIBILITY"],
@@ -62,8 +68,77 @@ Notes:
 - `input_type` supports: `url`, `email_headers`, `email_file`.
 - `content` is the raw value to analyze for the declared `input_type`.
 - URL-only controls (`allowlist_*`, `network_*`) are applied when `input_type="url"`.
+- `policy_id` is optional and applies only to `input_type="url"`; policy rules are merged with inline metadata using union semantics.
+- Missing `policy_id` returns structured `404` (`POLICY_NOT_FOUND`).
 - `subject` overrides display label in wrapped response output.
 - Current v2 implementation returns wrapped `single` mode responses only.
+
+### GET `/api/v2/policies`
+
+Returns persisted policy packs.
+
+Success shape:
+
+```json
+{
+  "schema_version": "2.0",
+  "flow": "policies_list",
+  "item_count": 1,
+  "items": [
+    {
+      "id": "uuid",
+      "name": "corp-safe",
+      "description": "Trusted suppression profile",
+      "allowlist_domains": ["trusted.example"],
+      "allowlist_categories": ["NONE"],
+      "allowlist_findings": ["HMG002_PUNYCODE_VISIBILITY"],
+      "input_types": ["url"],
+      "enabled": true,
+      "created_at": "2026-03-11T22:00:00+00:00",
+      "updated_at": "2026-03-11T22:00:00+00:00",
+      "tags": ["prod"]
+    }
+  ]
+}
+```
+
+### POST `/api/v2/policies`
+
+Create a policy pack.
+
+```json
+{
+  "name": "corp-safe",
+  "description": "Trusted suppression profile",
+  "allowlist_domains": ["trusted.example"],
+  "allowlist_categories": ["NONE"],
+  "allowlist_findings": ["HMG002_PUNYCODE_VISIBILITY"],
+  "input_types": ["url"],
+  "enabled": true,
+  "tags": ["prod"]
+}
+```
+
+### GET `/api/v2/policies/{id}`
+
+Returns one policy pack by ID.
+
+### PUT `/api/v2/policies/{id}`
+
+Applies full/partial validated updates. At least one mutable field is required.
+
+### DELETE `/api/v2/policies/{id}`
+
+Deterministic delete shape:
+
+```json
+{
+  "schema_version": "2.0",
+  "flow": "policies_delete",
+  "id": "uuid",
+  "deleted": true
+}
+```
 
 ### POST `/api/v1/url/check`
 
@@ -287,6 +362,7 @@ Known error codes:
 - `QRC_IMAGE_READ_ERROR` (`400`)
 - `QRC_NO_PAYLOADS` (`400`)
 - `QRC_NO_URL_PAYLOADS` (`400`)
+- `POLICY_NOT_FOUND` (`404`)
 
 Validation errors (`422`) use FastAPI's default validation format and should be handled separately.
 
@@ -399,6 +475,6 @@ export async function postJson<T>(path: string, body: unknown): Promise<T> {
 ## Operational Notes
 
 - QR API now accepts uploaded image bytes and does not require server-local file paths.
+- Policy storage path defaults to `.lsh/policies.json`; override with `LSH_POLICY_STORE_DIR`.
 - Use timeout/retry policy in frontend for network-enabled URL checks.
-
 

--- a/src/lsh/adapters/api.py
+++ b/src/lsh/adapters/api.py
@@ -14,10 +14,20 @@ from lsh.adapters.api_models import (
     AnalyzeV2Response,
     ApiErrorEnvelope,
     EmailCheckResponse,
+    PolicyCreateRequest,
+    PolicyDeleteResponse,
+    PolicyItemResponse,
+    PolicyListResponse,
+    PolicyUpdateRequest,
     QRScanResponse,
     UrlCheckResponse,
 )
-from lsh.application import analyze_email, analyze_url
+from lsh.application import (
+    PolicyService,
+    analyze_email,
+    analyze_url,
+    resolve_metadata_with_policy,
+)
 from lsh.formatters.structured import (
     build_qr_scan_payload,
     build_single_result_payload,
@@ -76,6 +86,7 @@ class AnalyzeRequestV2(BaseModel):
     content: str = ""
     subject: str | None = None
     family: bool = False
+    policy_id: str | None = Field(default=None, min_length=1)
     allowlist_domains: list[str] = Field(default_factory=list)
     allowlist_categories: list[str] = Field(default_factory=list)
     allowlist_findings: list[str] = Field(default_factory=list)
@@ -158,6 +169,10 @@ _QR_ERROR_RESPONSES: dict[int | str, dict[str, Any]] = {
     503: {"model": ApiErrorEnvelope, "description": "Structured QR decoder-unavailable envelope."},
 }
 
+_POLICY_ERROR_RESPONSES: dict[int | str, dict[str, Any]] = {
+    404: {"model": ApiErrorEnvelope, "description": "Structured policy-not-found envelope."},
+}
+
 
 def _multipart_support_available() -> bool:
     return find_spec("multipart") is not None
@@ -175,13 +190,14 @@ def create_app() -> Any:
         version="0.1.0",
         description="Minimal API adapter for URL, email, and QR analysis flows.",
     )
+    policy_service = PolicyService()
     cors_origins = _cors_allowed_origins()
     if cors_origins:
         app.add_middleware(
             CORSMiddleware,
             allow_origins=cors_origins,
             allow_credentials=False,
-            allow_methods=["GET", "POST", "OPTIONS"],
+            allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS"],
             allow_headers=["*"],
         )
 
@@ -211,20 +227,99 @@ def create_app() -> Any:
             include_family=request.family,
         )
 
+    @app.get("/api/v2/policies", response_model=PolicyListResponse)
+    def list_policies_v2() -> dict[str, object]:
+        policies = policy_service.list_policies()
+        return {
+            "schema_version": _SCHEMA_VERSION_V2,
+            "flow": "policies_list",
+            "item_count": len(policies),
+            "items": [policy.model_dump(mode="json") for policy in policies],
+        }
+
+    @app.get(
+        "/api/v2/policies/{id}",
+        response_model=PolicyItemResponse,
+        responses=_POLICY_ERROR_RESPONSES,
+    )
+    def get_policy_v2(id: str) -> dict[str, object]:
+        policy = policy_service.get_policy(id)
+        if policy is None:
+            raise _api_error(
+                status_code=404,
+                code="POLICY_NOT_FOUND",
+                message=f"Policy '{id}' was not found.",
+            )
+        return {
+            "schema_version": _SCHEMA_VERSION_V2,
+            "flow": "policies_get",
+            "item": policy.model_dump(mode="json"),
+        }
+
+    @app.post("/api/v2/policies", response_model=PolicyItemResponse, status_code=201)
+    def create_policy_v2(request: PolicyCreateRequest) -> dict[str, object]:
+        created = policy_service.create_policy(request.to_policy_pack())
+        return {
+            "schema_version": _SCHEMA_VERSION_V2,
+            "flow": "policies_create",
+            "item": created.model_dump(mode="json"),
+        }
+
+    @app.put(
+        "/api/v2/policies/{id}",
+        response_model=PolicyItemResponse,
+        responses=_POLICY_ERROR_RESPONSES,
+    )
+    def update_policy_v2(id: str, request: PolicyUpdateRequest) -> dict[str, object]:
+        updated = policy_service.update_policy(id, request.to_updates())
+        if updated is None:
+            raise _api_error(
+                status_code=404,
+                code="POLICY_NOT_FOUND",
+                message=f"Policy '{id}' was not found.",
+            )
+        return {
+            "schema_version": _SCHEMA_VERSION_V2,
+            "flow": "policies_update",
+            "item": updated.model_dump(mode="json"),
+        }
+
+    @app.delete("/api/v2/policies/{id}", response_model=PolicyDeleteResponse)
+    def delete_policy_v2(id: str) -> dict[str, object]:
+        deleted = policy_service.delete_policy(id)
+        return {
+            "schema_version": _SCHEMA_VERSION_V2,
+            "flow": "policies_delete",
+            "id": id,
+            "deleted": deleted,
+        }
+
     @app.post("/api/v2/analyze", response_model=AnalyzeV2Response, response_model_exclude_none=True)
     def analyze_v2(request: AnalyzeRequestV2) -> dict[str, object]:
         if request.input_type == "url":
-            result = analyze_url(
-                request.content,
-                _url_metadata_values(
-                    allowlist_domains=request.allowlist_domains,
-                    allowlist_categories=request.allowlist_categories,
-                    allowlist_findings=request.allowlist_findings,
-                    network_enabled=request.network_enabled,
-                    network_max_hops=request.network_max_hops,
-                    network_timeout=request.network_timeout,
-                ),
+            metadata = _url_metadata_values(
+                allowlist_domains=request.allowlist_domains,
+                allowlist_categories=request.allowlist_categories,
+                allowlist_findings=request.allowlist_findings,
+                network_enabled=request.network_enabled,
+                network_max_hops=request.network_max_hops,
+                network_timeout=request.network_timeout,
             )
+            if request.policy_id is not None:
+                policy = policy_service.get_policy(request.policy_id)
+                if policy is None:
+                    raise _api_error(
+                        status_code=404,
+                        code="POLICY_NOT_FOUND",
+                        message=f"Policy '{request.policy_id}' was not found.",
+                    )
+                metadata = resolve_metadata_with_policy(
+                    metadata,
+                    policy,
+                    input_type=request.input_type,
+                )
+
+            result = analyze_url(request.content, metadata)
             subject = request.subject or request.content
         else:
             result = analyze_email(request.content, input_type=request.input_type)
@@ -338,5 +433,4 @@ def create_app() -> Any:
 
 
 app: Any | None = create_app() if FASTAPI_AVAILABLE else None
-
 

--- a/src/lsh/adapters/api_models.py
+++ b/src/lsh/adapters/api_models.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Annotated, Literal
+from typing import Annotated, Literal, cast
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from lsh.core.models import AnalysisResult
+from lsh.core.policy import PolicyPack
 
 
 class _StrictModel(BaseModel):
@@ -143,6 +144,65 @@ class AnalyzeV2Response(_StrictModel):
     input_type: Literal["url", "email_headers", "email_file"]
     item_count: Literal[1]
     item: WrappedItemV2
+
+
+class PolicyCreateRequest(_StrictModel):
+    name: str = Field(min_length=1, max_length=120)
+    description: str = ""
+    allowlist_domains: list[str] = Field(default_factory=list)
+    allowlist_categories: list[str] = Field(default_factory=list)
+    allowlist_findings: list[str] = Field(default_factory=list)
+    input_types: list[Literal["url", "email_headers", "email_file"]] = Field(
+        default_factory=lambda: cast(
+            list[Literal["url", "email_headers", "email_file"]],
+            ["url"],
+        )
+    )
+    enabled: bool = True
+    tags: list[str] = Field(default_factory=list)
+
+    def to_policy_pack(self) -> PolicyPack:
+        return PolicyPack.model_validate(self.model_dump())
+
+
+class PolicyUpdateRequest(_StrictModel):
+    name: str | None = Field(default=None, min_length=1, max_length=120)
+    description: str | None = None
+    allowlist_domains: list[str] | None = None
+    allowlist_categories: list[str] | None = None
+    allowlist_findings: list[str] | None = None
+    input_types: list[Literal["url", "email_headers", "email_file"]] | None = None
+    enabled: bool | None = None
+    tags: list[str] | None = None
+
+    @model_validator(mode="after")
+    def _validate_non_empty_update(self) -> PolicyUpdateRequest:
+        if not self.model_dump(exclude_none=True):
+            raise ValueError("At least one field must be provided.")
+        return self
+
+    def to_updates(self) -> dict[str, object]:
+        return self.model_dump(exclude_none=True)
+
+
+class PolicyListResponse(_StrictModel):
+    schema_version: Literal["2.0"]
+    flow: Literal["policies_list"]
+    item_count: int = Field(ge=0)
+    items: list[PolicyPack]
+
+
+class PolicyItemResponse(_StrictModel):
+    schema_version: Literal["2.0"]
+    flow: Literal["policies_get", "policies_create", "policies_update"]
+    item: PolicyPack
+
+
+class PolicyDeleteResponse(_StrictModel):
+    schema_version: Literal["2.0"]
+    flow: Literal["policies_delete"]
+    id: str
+    deleted: bool
 
 
 class QRLegacyResultItem(_StrictModel):

--- a/src/lsh/application/__init__.py
+++ b/src/lsh/application/__init__.py
@@ -1,8 +1,12 @@
 """Application-layer services for orchestrating analysis flows."""
 
 from lsh.application.analysis_service import analyze_email, analyze_url
+from lsh.application.policy_resolver import resolve_metadata_with_policy
+from lsh.application.policy_service import PolicyService
 
 __all__ = [
+    "PolicyService",
     "analyze_email",
     "analyze_url",
+    "resolve_metadata_with_policy",
 ]

--- a/src/lsh/application/policy_service.py
+++ b/src/lsh/application/policy_service.py
@@ -1,0 +1,50 @@
+"""Application service wrapper for policy-pack persistence operations."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+from lsh.core.policy import PolicyPack
+from lsh.core.policy_store import PolicyStore
+
+
+class PolicyService:
+    """Typed application seam over the file-backed policy store."""
+
+    def __init__(self, store: PolicyStore | None = None) -> None:
+        self._store = store or PolicyStore()
+
+    def list_policies(self) -> list[PolicyPack]:
+        return self._store.list_policies()
+
+    def get_policy(self, policy_id: str) -> PolicyPack | None:
+        return self._store.get_policy(policy_id)
+
+    def create_policy(self, policy: PolicyPack) -> PolicyPack:
+        # Re-validate to keep service behavior deterministic for all callers.
+        validated = PolicyPack.model_validate(policy.model_dump())
+        return self._store.create_policy(validated)
+
+    def update_policy(
+        self,
+        policy_id: str,
+        updates: Mapping[str, object],
+    ) -> PolicyPack | None:
+        existing = self._store.get_policy(policy_id)
+        if existing is None:
+            return None
+
+        merged = existing.model_dump()
+        for key, value in updates.items():
+            if key not in {"id", "created_at", "updated_at"}:
+                merged[key] = value
+
+        validated = PolicyPack.model_validate(merged)
+        persisted_updates = validated.model_dump(
+            mode="json",
+            exclude={"id", "created_at", "updated_at"},
+        )
+        return self._store.update_policy(policy_id, persisted_updates)
+
+    def delete_policy(self, policy_id: str) -> bool:
+        return self._store.delete_policy(policy_id)

--- a/tests/adapters/test_api.py
+++ b/tests/adapters/test_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from pathlib import Path
 
 import pytest
 
@@ -20,6 +21,14 @@ _QR_UPLOADS_SKIP = pytest.mark.skipif(
 def _client() -> TestClient:
     app = api.create_app()
     return TestClient(app)
+
+
+def _client_with_policy_store(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> TestClient:
+    monkeypatch.setenv("LSH_POLICY_STORE_DIR", str(tmp_path / "policy-store"))
+    return TestClient(api.create_app())
 
 
 def _qr_upload(
@@ -633,3 +642,262 @@ def test_qr_scan_requires_upload_file() -> None:
 
 
 
+
+
+def _create_policy(
+    client: TestClient,
+    **overrides: object,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "name": "test-policy",
+        "description": "default",
+        "allowlist_domains": [],
+        "allowlist_categories": [],
+        "allowlist_findings": [],
+        "input_types": ["url"],
+        "enabled": True,
+        "tags": [],
+    }
+    payload.update(overrides)
+    response = client.post("/api/v2/policies", json=payload)
+    assert response.status_code == 201
+    return response.json()["item"]
+
+
+def test_v2_policies_crud_round_trip(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client_with_policy_store(tmp_path, monkeypatch)
+
+    create_response = client.post(
+        "/api/v2/policies",
+        json={
+            "name": "corp-safe",
+            "description": "Trusted suppression profile",
+            "allowlist_domains": ["xn--pple-43d.com"],
+            "allowlist_categories": ["NONE"],
+            "allowlist_findings": ["HMG002_PUNYCODE_VISIBILITY"],
+            "input_types": ["url"],
+            "enabled": True,
+            "tags": ["prod"],
+        },
+    )
+    assert create_response.status_code == 201
+    created = create_response.json()
+    assert created["schema_version"] == "2.0"
+    assert created["flow"] == "policies_create"
+
+    policy_id = created["item"]["id"]
+
+    list_response = client.get("/api/v2/policies")
+    assert list_response.status_code == 200
+    listed = list_response.json()
+    assert listed["schema_version"] == "2.0"
+    assert listed["flow"] == "policies_list"
+    assert listed["item_count"] == 1
+    assert listed["items"][0]["id"] == policy_id
+
+    get_response = client.get(f"/api/v2/policies/{policy_id}")
+    assert get_response.status_code == 200
+    fetched = get_response.json()
+    assert fetched["flow"] == "policies_get"
+    assert fetched["item"]["name"] == "corp-safe"
+
+    update_response = client.put(
+        f"/api/v2/policies/{policy_id}",
+        json={
+            "description": "Updated profile",
+            "enabled": False,
+            "tags": ["prod", "archived"],
+        },
+    )
+    assert update_response.status_code == 200
+    updated = update_response.json()
+    assert updated["flow"] == "policies_update"
+    assert updated["item"]["description"] == "Updated profile"
+    assert updated["item"]["enabled"] is False
+    assert updated["item"]["name"] == "corp-safe"
+
+    delete_response = client.delete(f"/api/v2/policies/{policy_id}")
+    assert delete_response.status_code == 200
+    deleted = delete_response.json()
+    assert deleted == {
+        "schema_version": "2.0",
+        "flow": "policies_delete",
+        "id": policy_id,
+        "deleted": True,
+    }
+
+    delete_again = client.delete(f"/api/v2/policies/{policy_id}")
+    assert delete_again.status_code == 200
+    assert delete_again.json()["deleted"] is False
+
+
+def test_v2_policy_get_not_found_uses_error_envelope(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client_with_policy_store(tmp_path, monkeypatch)
+
+    response = client.get("/api/v2/policies/missing-policy")
+    assert response.status_code == 404
+    detail = response.json()["detail"]
+    assert detail["schema_version"] == "1.0"
+    assert detail["error"]["code"] == "POLICY_NOT_FOUND"
+
+
+def test_v2_policy_update_not_found_uses_error_envelope(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client_with_policy_store(tmp_path, monkeypatch)
+
+    response = client.put(
+        "/api/v2/policies/missing-policy",
+        json={"description": "updated"},
+    )
+    assert response.status_code == 404
+    detail = response.json()["detail"]
+    assert detail["schema_version"] == "1.0"
+    assert detail["error"]["code"] == "POLICY_NOT_FOUND"
+
+
+def test_v2_policy_create_validation_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client_with_policy_store(tmp_path, monkeypatch)
+
+    response = client.post(
+        "/api/v2/policies",
+        json={"name": "", "input_types": ["url"]},
+    )
+    assert response.status_code == 422
+
+
+def test_v2_policy_update_validation_error_for_empty_payload(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client_with_policy_store(tmp_path, monkeypatch)
+    created = _create_policy(client)
+
+    response = client.put(
+        f"/api/v2/policies/{created['id']}",
+        json={},
+    )
+    assert response.status_code == 422
+
+
+def test_v2_analyze_with_policy_id_applies_stored_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client_with_policy_store(tmp_path, monkeypatch)
+    created = _create_policy(
+        client,
+        name="suppress-punycode",
+        allowlist_domains=["xn--pple-43d.com"],
+        allowlist_categories=["NONE"],
+        allowlist_findings=["HMG002_PUNYCODE_VISIBILITY"],
+    )
+
+    response = client.post(
+        "/api/v2/analyze",
+        json={
+            "input_type": "url",
+            "content": "https://xn--pple-43d.com",
+            "policy_id": created["id"],
+        },
+    )
+    assert response.status_code == 200
+
+    body = response.json()
+    findings = body["item"]["result"]["findings"]
+    categories = {finding["category"] for finding in findings}
+    assert "HMG002_PUNYCODE_VISIBILITY" not in categories
+    assert "HMG003_MIXED_SCRIPT_HOSTNAME" in categories
+
+
+def test_v2_analyze_with_policy_id_missing_returns_404(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client_with_policy_store(tmp_path, monkeypatch)
+
+    response = client.post(
+        "/api/v2/analyze",
+        json={
+            "input_type": "url",
+            "content": "https://example.com",
+            "policy_id": "missing-policy",
+        },
+    )
+    assert response.status_code == 404
+    detail = response.json()["detail"]
+    assert detail["schema_version"] == "1.0"
+    assert detail["error"]["code"] == "POLICY_NOT_FOUND"
+
+
+def test_v2_analyze_policy_and_inline_metadata_union(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client_with_policy_store(tmp_path, monkeypatch)
+    created = _create_policy(
+        client,
+        name="union-check",
+        allowlist_domains=["xn--pple-43d.com"],
+        allowlist_categories=["NONE"],
+        allowlist_findings=["HMG002_PUNYCODE_VISIBILITY"],
+    )
+
+    response = client.post(
+        "/api/v2/analyze",
+        json={
+            "input_type": "url",
+            "content": "https://xn--pple-43d.com",
+            "policy_id": created["id"],
+            "allowlist_domains": ["xn--pple-43d.com"],
+            "allowlist_categories": ["none"],
+            "allowlist_findings": ["hmg003_mixed_script_hostname"],
+        },
+    )
+    assert response.status_code == 200
+
+    body = response.json()
+    findings = body["item"]["result"]["findings"]
+    categories = {finding["category"] for finding in findings}
+    assert "HMG002_PUNYCODE_VISIBILITY" not in categories
+    assert "HMG003_MIXED_SCRIPT_HOSTNAME" not in categories
+
+    suppression_trace = body["item"]["analyst"]["suppression_trace"]
+    configured_findings = set(suppression_trace["configured_allowlist_findings"])
+    assert configured_findings == {
+        "HMG002_PUNYCODE_VISIBILITY",
+        "HMG003_MIXED_SCRIPT_HOSTNAME",
+    }
+
+
+def test_openapi_includes_typed_policy_routes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client_with_policy_store(tmp_path, monkeypatch)
+    schema = client.get("/openapi.json").json()
+
+    list_success = schema["paths"]["/api/v2/policies"]["get"]["responses"]["200"]["content"][
+        "application/json"
+    ]["schema"]
+    assert "$ref" in list_success or "allOf" in list_success
+
+    item_success = schema["paths"]["/api/v2/policies/{id}"]["get"]["responses"]["200"][
+        "content"
+    ]["application/json"]["schema"]
+    assert "$ref" in item_success or "allOf" in item_success
+
+    not_found_error = schema["paths"]["/api/v2/policies/{id}"]["get"]["responses"]["404"][
+        "content"
+    ]["application/json"]["schema"]
+    assert "$ref" in not_found_error


### PR DESCRIPTION
## Summary

Implements the E5 backend feature slice for policy packs:
- adds `/api/v2/policies` CRUD endpoints
- adds optional `policy_id` support to `/api/v2/analyze` for URL input
- preserves existing behavior when `policy_id` is omitted
- keeps all v1 endpoints unchanged

## What Changed

### API
- Added:
  - `GET /api/v2/policies`
  - `GET /api/v2/policies/{id}`
  - `POST /api/v2/policies`
  - `PUT /api/v2/policies/{id}` (validated partial/full update)
  - `DELETE /api/v2/policies/{id}` (deterministic `{ id, deleted }` result)
- Added structured `404` error envelope for missing policies:
  - `POLICY_NOT_FOUND`

### Analyze v2 integration
- Extended `AnalyzeRequestV2` with `policy_id: str | None`
- For `input_type="url"` with `policy_id`:
  - loads stored policy
  - returns `404 POLICY_NOT_FOUND` if missing
  - merges policy + inline metadata via `resolve_metadata_with_policy(...)`
- Preserves current behavior exactly when `policy_id` is not provided

### Service layer
- Added `PolicyService` app-layer seam over `PolicyStore` to keep storage details out of adapter handlers

### Tests
- Added adapter tests for:
  - policy CRUD success paths
  - policy get/update not found
  - policy validation errors
  - `/api/v2/analyze` with `policy_id`:
    - applies policy when found
    - returns 404 when missing
    - preserves inline+policy union behavior
- Regression parity test remains green

### Docs
- Updated docs for:
  - new `/api/v2/policies` endpoints
  - `policy_id` in `/api/v2/analyze`
  - `LSH_POLICY_STORE_DIR` behavior

## Verification

- `python -m pytest tests/core/test_policy.py tests/core/test_policy_store.py tests/application/test_policy_resolver.py -q` ✅
- `python -m pytest tests/adapters/test_api.py -q` ✅
- `python -m pytest tests/contracts/test_v1_v2_snapshot_parity.py -q` ✅
- `python -m pytest -q` ✅
- `python -m ruff check src tests` ✅
- `python -m mypy src` ✅

## Notes

- Deferred `.gitattributes` line-ending normalization to a separate cleanup change (non-blocking).
