### PR TITLE
chore: refresh re-entry validation baseline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 Link Safety Hub (LSH) is a modular, local-first security toolbelt for URL, email-header, and QR-linked analysis.
 It targets clear risk decisions first, with technical evidence available when needed.
 
-## Current State (2026-03-09)
+## Current State (2026-05-28)
 
 Implemented:
 
@@ -22,19 +22,25 @@ Implemented:
 - Next.js UI with unified `/analyze` workspace (Quick + Analyst modes)
 - Verdict-first UX (`VerdictCard`, `WhyPanel`, action-level mapping)
 - URL Analyst Mode with domain anatomy, redirect path, suppression traces, compare-ready evidence keys
+- E5 backend policy-pack foundation:
+  - typed `PolicyPack` model and file-backed `PolicyStore`
+  - `PolicyService` application seam
+  - `/api/v2/policies` CRUD routes
+  - `POST /api/v2/analyze` URL `policy_id` integration with policy + inline suppression union semantics
 - Docker deployment baseline
-- Expanded regression coverage (223 tests):
+- Expanded regression coverage (282 pytest tests):
   - adversarial URL tests
   - v1/v2 parity and edge-case matrix tests
   - snapshot parity fixtures in `tests/fixtures/contracts/`
   - browser smoke tests for unified workspace and verdict UX
 - V2 phases E1-E4 complete (epics `#3`-`#6` closed)
+- E5 backend model/store/API work landed; E5 remains open for frontend policy selection, dry-run preview, and policy audit logging
 
 Open priorities:
 
-1. Complete hosted validation pass (Session 9 roadmap item 3).
-2. Start E5: Policy Packs and suppression management (`#7`).
-3. Continue with E6-E8 per V2 roadmap.
+1. Build E5 frontend policy selection/UI (`PolicyDrawer` or equivalent) for epic `#7`.
+2. Add E5 policy dry-run preview and policy audit logging.
+3. Keep E6 history, compare, rerun, and feedback persistence separate until the remaining E5 policy UX/audit work is complete.
 
 ## Tech Stack
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ cd ui && npm run lint && npm run build  # frontend
 
 **Detection modules**: `homoglyph` (Unicode/IDN), `ascii_lookalike` (leet/brand), `url_structure` (deceptive patterns), `net_ip` (IP literals), `redirect` (opt-in redirect chains), `email_auth` (SPF/DKIM/DMARC), `qr_decode` (QR payload extraction).
 
-## Current Status (2026-03-09)
+## Current Status (2026-05-28)
 
 Implemented now:
 
@@ -69,6 +69,11 @@ Implemented now:
 - Reusable family formatter layer in `src/lsh/formatters/family.py`
 - Reusable structured response wrappers in `src/lsh/formatters/structured.py`
 - Unified v2 endpoint (`POST /api/v2/analyze`) plus v1/v2 parity, analyst projections, policy-pack `policy_id` support, and edge-case test coverage
+- E5 backend policy-pack foundation:
+  - typed `PolicyPack` model and file-backed `PolicyStore`
+  - `PolicyService` application seam
+  - `/api/v2/policies` CRUD routes
+  - URL analyze `policy_id` integration with policy + inline suppression union semantics
 - URL-focused offline modules:
   - `homoglyph` (Unicode/IDN spoofing)
   - `ascii_lookalike` (ASCII glyph and leet brand lookalikes)
@@ -97,9 +102,12 @@ Implemented now:
 
 In progress and next:
 
+- E5 frontend policy selection/UI remains pending; the backend model/store/API slice has landed
+- E5 dry-run preview and policy audit logging remain future work
+- Persisted history/compare flows remain future E6 work
 - Hosted validation closure for Session 9 deployment checklist
 - Email/QR analyst-mode parity beyond the current URL-first slice
-- Persisted history/compare flows and hardening milestones (tracked in `docs/V2_ROADMAP_ISSUES.md`)
+- Hardening milestones remain tracked in `docs/V2_ROADMAP_ISSUES.md`
 
 ## Quick Start
 
@@ -427,4 +435,3 @@ Agent workflow docs:
 ## License
 
 MIT
-

--- a/SESSION_LOG.md
+++ b/SESSION_LOG.md
@@ -2415,3 +2415,48 @@ Development session history. Each entry documents what was done, why, and what's
 - `python -m ruff check src tests` passed.
 - `python -m mypy src` passed.
 - `git diff --check` clean (no whitespace/check failures).
+
+---
+
+## 2026-05-28 - Re-entry cleanup baseline normalization
+
+**Agent:** Codex
+
+**Branch:** `chore/reentry-cleanup`
+
+**Goal:** Normalize the local validation baseline after the E5 backend policy-pack work landed on `main`, fix known UI/tooling failures, and sync roadmap/checklist docs without adding product features.
+
+**Module(s) Touched:** UI e2e harness, UI lint tooling, API/client contract types, docs/status trackers, lint-only Python baseline fixes
+
+**Changes:**
+- Updated `ui/e2e/analyze.verdict.spec.ts` to scope verdict and analyst assertions to the intended panels, fixing strict-locator failures from duplicate visible text.
+- Replaced deprecated `next lint` usage in `ui/package.json` with `eslint .`, using the existing flat ESLint config.
+- Added optional `policy_id` to the typed UI `AnalyzeV2Request` contract without adding policy-management UI.
+- Synced `README.md`, `docs/ROADMAP.md`, and `docs/V2_ROADMAP_ISSUES.md` to show E5 backend policy model/store/API work as landed while E5 frontend selection, dry-run, and audit remain pending.
+- Documented that explicit v2 policy errors still use the existing `detail.schema_version: "1.0"` error envelope pending a deliberate versioning decision.
+- Fixed current ruff/mypy baseline drift with no behavior change:
+  - modernized three `isinstance` calls in QR/redirect modules for current ruff.
+  - removed a stale mypy file-level error-code directive from `src/lsh/adapters/api.py`.
+
+**Decisions:**
+- Kept E5 frontend policy UI out of scope; this session only synced docs/types to the backend contract already present.
+- Treated ruff/mypy failures as validation-baseline cleanup because they were mechanical current-tooling issues and did not alter policy or detection behavior.
+- Preserved explicit API error-envelope behavior (`schema_version: "1.0"`) and documented the future contract decision instead of changing it.
+
+**Open Questions:**
+- Should v2 endpoint-raised errors move to a v2 error envelope, or should the existing shared error envelope remain the stable error contract across API versions?
+
+**Next:**
+- Start the next E5 session on frontend policy selection/UI (`PolicyDrawer` or equivalent), then follow with policy dry-run preview and audit logging.
+- Keep E6 history/compare/rerun/feedback persistence separate from E5 completion work.
+
+**Tests / Verification:**
+- `ruff check src tests --no-cache` passed.
+- `mypy src` passed.
+- `pytest -q` passed (`282 passed`).
+- `npm run typecheck` passed in `ui/`.
+- `npm run lint` passed in `ui/`.
+- `npm run build` passed in `ui/`.
+- `npx playwright test e2e/analyze.verdict.spec.ts` passed in `ui/` (`3 passed`).
+- `npm run smoke:api` passed in `ui/` against local API `http://127.0.0.1:8000`.
+- `npm run smoke:e2e` passed in `ui/` against local API + built UI (`3 passed`).

--- a/SESSION_LOG.md
+++ b/SESSION_LOG.md
@@ -2437,6 +2437,7 @@ Development session history. Each entry documents what was done, why, and what's
 - Fixed current ruff/mypy baseline drift with no behavior change:
   - modernized three `isinstance` calls in QR/redirect modules for current ruff.
   - removed a stale mypy file-level error-code directive from `src/lsh/adapters/api.py`.
+  - follow-up commit `e0073c8` removed the stale `# type: ignore[import-untyped]` from `src/lsh/modules/redirect/analyzer.py` after the requests typing baseline no longer required it.
 
 **Decisions:**
 - Kept E5 frontend policy UI out of scope; this session only synced docs/types to the backend contract already present.

--- a/docs/API_INTEGRATION.md
+++ b/docs/API_INTEGRATION.md
@@ -366,6 +366,10 @@ Known error codes:
 
 Validation errors (`422`) use FastAPI's default validation format and should be handled separately.
 
+Contract decision pending: explicit endpoint-raised errors for v2 policy flows currently reuse the
+existing `detail.schema_version: "1.0"` error envelope. Do not change this to a v2 error envelope
+without a deliberate versioning decision and consumer migration note.
+
 ## v1/v2 Snapshot Governance (E1-I4)
 
 Deterministic overlap fixture and parity assertions live in:
@@ -477,4 +481,3 @@ export async function postJson<T>(path: string, body: unknown): Promise<T> {
 - QR API now accepts uploaded image bytes and does not require server-local file paths.
 - Policy storage path defaults to `.lsh/policies.json`; override with `LSH_POLICY_STORE_DIR`.
 - Use timeout/retry policy in frontend for network-enabled URL checks.
-

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-## Current Progress (2026-03-09)
+## Current Progress (2026-05-28)
 
 - [x] Session 0: Package scaffold, core models, scorer, CLI skeleton
 - [x] Session 1: Homoglyph / IDN module with focused tests
@@ -33,6 +33,7 @@
 - [x] Session 12: Unified `/analyze` workspace (URL/Email/QR tabs, typed v2 client, mode toggle, e2e smoke)
 - [x] Session 13: Verdict-first UX slice (`VerdictCard`, `WhyPanel`, action-level mapping)
 - [x] Session 14: URL Analyst Mode deep evidence (analyst payloads, suppression traces, compare-ready keys)
+- [x] Session 15: E5 backend policy-pack foundation (model/store, `/api/v2/policies` CRUD, analyze `policy_id` integration)
 
 ## Session 8: Deployment + UI Validation
 
@@ -161,6 +162,27 @@ Finish the first shippable URL Analyst Mode surface and make the v2 contract rea
 3. [x] Add suppression-trace visibility from allowlist decisions through API and UI.
 4. [x] Add compare-ready evidence keys (`finding_key`, `compare_key`, keyed evidence maps) for future delta views.
 5. [x] Sync API/docs/roadmap state with the delivered analyst-mode contract.
+
+## Session 15: E5 Backend Policy-Pack Foundation (2026-03-11)
+
+### Goal
+
+Land the backend half of policy packs without starting the policy-management UI.
+
+### Work Items
+
+1. [x] Add `PolicyPack` data model and file-backed `PolicyStore`.
+2. [x] Add `PolicyService` application seam for persistence operations.
+3. [x] Add typed `/api/v2/policies` CRUD endpoints.
+4. [x] Add optional `policy_id` support to URL requests on `POST /api/v2/analyze`.
+5. [x] Preserve v1 behavior and existing explicit API error-envelope versioning.
+6. [ ] Build E5 frontend policy selection/UI (`PolicyDrawer` or equivalent).
+7. [ ] Add policy dry-run preview.
+8. [ ] Add policy audit logging.
+
+### Current Boundary
+
+The E5 backend model/store/API slice has landed. The E5 epic remains open until users can manage and apply policies from the UI, dry-run policy effects, and inspect policy audit history. History, compare, rerun, and feedback persistence remain E6 work.
 
 ## Risks and Mitigations
 

--- a/docs/V2_ROADMAP_ISSUES.md
+++ b/docs/V2_ROADMAP_ISSUES.md
@@ -1,6 +1,6 @@
 # V2 Roadmap and Issue Tracker
 
-Updated: 2026-03-09
+Updated: 2026-05-28
 Owner: Product + Engineering
 Status: Execution tracker
 
@@ -141,19 +141,22 @@ Epic issues are now created and linked below.
 ### Scope
 
 1. Turn allowlist/suppression into first-class policy management.
+2. Backend model/store/API support has landed.
+3. Frontend policy selection, dry-run preview, and audit visibility remain pending.
 
 ### Child issues
 
-- [ ] `E5-I1` Create policy pack data model and storage.
-- [ ] `E5-I2` Add `/api/v2/policies` CRUD endpoints.
-- [ ] `E5-I3` Build `PolicyDrawer` with scoped controls.
+- [x] `E5-I1` Create policy pack data model and storage. Backend landed via PRs `#15`/`#16`.
+- [x] `E5-I2` Add `/api/v2/policies` CRUD endpoints and `POST /api/v2/analyze` `policy_id` integration. Backend landed via PR `#16`.
+- [ ] `E5-I3` Build `PolicyDrawer` with scoped controls and frontend policy selection.
 - [ ] `E5-I4` Add policy dry-run preview.
 - [ ] `E5-I5` Add policy audit logging.
 
 ### Definition of done
 
-1. Policy packs can be created, edited, and applied in UI.
-2. Suppression behavior is transparent and test-covered.
+1. Backend policy packs can be created, edited, deleted, and applied to URL analysis by `policy_id`.
+2. Policy packs can be created, edited, selected, and applied in UI.
+3. Suppression behavior is transparent, dry-runnable, audited, and test-covered.
 
 ## E6: History, Compare, Feedback
 

--- a/src/lsh/adapters/api.py
+++ b/src/lsh/adapters/api.py
@@ -1,5 +1,4 @@
 """Minimal FastAPI adapter for Link Safety Hub."""
-# mypy: disable-error-code=untyped-decorator
 # mypy: warn_unused_ignores=False
 
 from __future__ import annotations
@@ -433,4 +432,3 @@ def create_app() -> Any:
 
 
 app: Any | None = create_app() if FASTAPI_AVAILABLE else None
-

--- a/src/lsh/modules/qr_decode/analyzer.py
+++ b/src/lsh/modules/qr_decode/analyzer.py
@@ -62,7 +62,7 @@ def decode_qr_payloads_from_image(image_path: str | Path) -> list[str]:
     seen: set[str] = set()
     for obj in decoded_objects:
         raw_data = getattr(obj, "data", b"")
-        if not isinstance(raw_data, (bytes, bytearray)):
+        if not isinstance(raw_data, bytes | bytearray):
             continue
         text = bytes(raw_data).decode("utf-8", errors="replace").strip()
         if not text or text in seen:
@@ -95,7 +95,7 @@ def decode_qr_payloads_from_bytes(
     seen: set[str] = set()
     for obj in decoded_objects:
         raw_data = getattr(obj, "data", b"")
-        if not isinstance(raw_data, (bytes, bytearray)):
+        if not isinstance(raw_data, bytes | bytearray):
             continue
         text = bytes(raw_data).decode("utf-8", errors="replace").strip()
         if not text or text in seen:

--- a/src/lsh/modules/redirect/analyzer.py
+++ b/src/lsh/modules/redirect/analyzer.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from urllib.parse import urljoin
 
-import requests  # type: ignore[import-untyped]
+import requests
 
 from lsh.core.models import AnalysisInput, Confidence, Evidence, Finding, ModuleInterface, Severity
 from lsh.core.url_tools import extract_hostname, parse_url_like, registrable_domain

--- a/src/lsh/modules/redirect/analyzer.py
+++ b/src/lsh/modules/redirect/analyzer.py
@@ -23,7 +23,7 @@ def _network_enabled(input: AnalysisInput) -> bool:
     raw = input.metadata.get("network_enabled", False)
     if isinstance(raw, bool):
         return raw
-    if isinstance(raw, (int, float)):
+    if isinstance(raw, int | float):
         return raw != 0
     if isinstance(raw, str):
         normalized = raw.strip().lower()

--- a/ui/e2e/analyze.verdict.spec.ts
+++ b/ui/e2e/analyze.verdict.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { expect, test, type Locator, type Page } from "@playwright/test";
 
 const SAFE_URL_RESPONSE = {
   schema_version: "2.0",
@@ -312,6 +312,10 @@ async function gotoAnalyze(page: Page) {
   await expect(page.getByRole("heading", { name: "Unified Analyze Workspace" })).toBeVisible();
 }
 
+function panelByHeading(page: Page, headingName: string): Locator {
+  return page.getByRole("heading", { name: headingName }).locator("xpath=ancestor::section[1]");
+}
+
 test("quick mode presents a safe decision without analyst-only details", async ({ page }) => {
   await page.route("**/api/v2/analyze", async (route) => {
     await route.fulfill({
@@ -327,11 +331,12 @@ test("quick mode presents a safe decision without analyst-only details", async (
 
   await expect(page.getByText("Action: Safe")).toBeVisible();
   await expect(page.getByText("Safe to continue")).toBeVisible();
+  const safeVerdictPanel = panelByHeading(page, "Safe to continue");
   await expect(
     page.getByText("This destination did not show strong warning signs in this scan.")
   ).toBeVisible();
   await expect(
-    page.getByText(
+    safeVerdictPanel.getByText(
       "Proceed only if you expected this item, and use trusted bookmarks for sensitive accounts."
     )
   ).toBeVisible();
@@ -354,15 +359,30 @@ test("analyst mode renders URL-specific panels from structured v2 payloads", asy
   await page.getByRole("tab", { name: "Analyst" }).click();
 
   await expect(page.getByRole("heading", { name: "Contract summary" })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Domain anatomy" })).toBeVisible();
-  await expect(page.getByText("login.example.test")).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Redirect path" })).toBeVisible();
-  await expect(page.getByText("Cross-domain redirect")).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Suppression trace" })).toBeVisible();
-  await expect(page.getByText("Suppressed: 1")).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Evidence panel" })).toBeVisible();
-  await expect(page.getByText("Suspicious brand token appears in a subdomain")).toBeVisible();
-  await expect(page.getByRole("button", { name: "redirect" })).toBeVisible();
+
+  const domainPanel = panelByHeading(page, "Domain anatomy");
+  await expect(domainPanel).toBeVisible();
+  await expect(
+    domainPanel
+      .locator(".metricCard")
+      .filter({ hasText: "Hostname" })
+      .filter({ hasText: "login.example.test" })
+  ).toBeVisible();
+
+  const redirectPanel = panelByHeading(page, "Redirect path");
+  await expect(redirectPanel).toBeVisible();
+  await expect(redirectPanel.getByText("Cross-domain redirect", { exact: true })).toBeVisible();
+
+  const suppressionPanel = panelByHeading(page, "Suppression trace");
+  await expect(suppressionPanel).toBeVisible();
+  await expect(suppressionPanel.getByText("Suppressed: 1", { exact: true })).toBeVisible();
+
+  const evidencePanel = panelByHeading(page, "Evidence panel");
+  await expect(evidencePanel).toBeVisible();
+  await expect(
+    evidencePanel.getByText("Suspicious brand token appears in a subdomain", { exact: true })
+  ).toBeVisible();
+  await expect(evidencePanel.getByRole("button", { name: "redirect" })).toBeVisible();
   await expect(page.getByRole("heading", { name: "Raw JSON" })).toHaveCount(0);
 });
 

--- a/ui/lib/api.ts
+++ b/ui/lib/api.ts
@@ -145,6 +145,7 @@ export interface AnalyzeV2Request {
   content: string;
   subject?: string;
   family?: boolean;
+  policy_id?: string;
   allowlist_domains?: string[];
   allowlist_categories?: string[];
   allowlist_findings?: string[];

--- a/ui/package.json
+++ b/ui/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "start:smoke": "next start --hostname 127.0.0.1 --port 3000",
-    "lint": "next lint",
+    "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "smoke:api": "node scripts/api-contract-smoke.mjs",
     "smoke:e2e": "playwright test e2e/analyze.smoke.spec.ts"


### PR DESCRIPTION
## Summary

- Fixed strict Playwright locator failures in the analyze verdict spec
- Replaced deprecated `next lint` usage with `eslint .`
- Synced README/roadmap/API docs with the landed E5 backend policy-pack work
- Added `policy_id` to the typed frontend v2 analyze request contract
- Applied mechanical ruff/mypy cleanup
- Appended re-entry session notes

## Validation

- [x] `ruff check src tests --no-cache`
- [x] `mypy src`
- [x] `pytest -q` — 282 passed
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run build`
- [x] `npx playwright test e2e/analyze.verdict.spec.ts` — 3 passed
- [x] `npm run smoke:api`
- [x] `npm run smoke:e2e` — 3 passed

## Notes

Explicit v2 policy errors still use `detail.schema_version: "1.0"`. This remains a documented API contract decision for a later session.

## Recommended review focus

- Confirm Playwright locator fixes are properly scoped and not brittle
- Confirm `eslint .` is correct for this repo after removing deprecated `next lint`
- Confirm optional `policy_id` in the frontend v2 analyze request type is safe and contract-aligned
- Confirm backend ruff/mypy edits are mechanical and do not change analyzer behavior
- Confirm docs accurately separate landed E5 backend work from pending E5 frontend UI, dry-run/audit, and E6 history/compare work