### PR TITLE
ux: simplify Analyze result presentation

### DIFF
--- a/ui/app/analyze/result-panels.tsx
+++ b/ui/app/analyze/result-panels.tsx
@@ -31,41 +31,56 @@ const CONFIDENCE_RANK: Record<ConfidenceLevel, number> = {
 const ACTION_COPY: Record<
   ActionLevel,
   {
-    badge: string;
-    title: string;
-    detail: string;
-    fallbackRecommendation: string;
+    verdictLabel: string;
+    riskLabel: string;
+    fallbackExplanation: string;
+    fallbackReasons: string[];
+    fallbackRecommendations: string[];
   }
 > = {
   safe: {
-    badge: "Safe",
-    title: "Safe to continue",
-    detail: "No strong warning signals were returned for this result.",
-    fallbackRecommendation:
-      "Proceed only if you expected this item, and use trusted bookmarks for sensitive accounts."
+    verdictLabel: "Safe",
+    riskLabel: "Low",
+    fallbackExplanation: "This destination did not show strong warning signs in this scan.",
+    fallbackReasons: ["No major warning signals were returned for this result."],
+    fallbackRecommendations: [
+      "Continue only if you expected this destination.",
+      "Use trusted bookmarks for sensitive accounts."
+    ]
   },
   caution: {
-    badge: "Caution",
-    title: "Pause and verify",
-    detail: "A mild warning sign was found, so a quick verification step is still worth it.",
-    fallbackRecommendation: "Pause and verify the destination or sender before taking action."
+    verdictLabel: "Caution",
+    riskLabel: "Medium",
+    fallbackExplanation: "This destination has some warning signs, so verify it before opening.",
+    fallbackReasons: ["A warning signal was found, but it does not require an automatic block."],
+    fallbackRecommendations: [
+      "Verify the destination through a trusted source.",
+      "Avoid entering sensitive information until you confirm it."
+    ]
   },
   avoid: {
-    badge: "Avoid",
-    title: "Avoid interacting for now",
-    detail: "This result shows strong warning signs that should stop a routine click-through.",
-    fallbackRecommendation:
-      "Avoid opening links, replying, or signing in until you verify the destination through a trusted path."
+    verdictLabel: "Suspicious",
+    riskLabel: "High",
+    fallbackExplanation: "This destination shows strong warning signs and should be avoided for now.",
+    fallbackReasons: ["The analysis found high-risk signals for this destination."],
+    fallbackRecommendations: [
+      "Do not enter credentials or personal information.",
+      "Verify the sender or destination through another channel.",
+      "Report this link to your security team."
+    ]
   },
   block: {
-    badge: "Block",
-    title: "Block and report",
-    detail: "This result has high-risk signals and should be treated as unsafe by default.",
-    fallbackRecommendation:
-      "Do not open or reply. Report it and use an official contact path instead."
+    verdictLabel: "Dangerous",
+    riskLabel: "Critical",
+    fallbackExplanation: "This destination looks unsafe and should be blocked or reported.",
+    fallbackReasons: ["The analysis found critical warning signals for this destination."],
+    fallbackRecommendations: [
+      "Do not open the link or reply to the request.",
+      "Report it to your security team.",
+      "Use an official website or contact path instead."
+    ]
   }
 };
-
 
 function getString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value : null;
@@ -251,29 +266,12 @@ function getActionLevel(item: ApiItem): ActionLevel {
   return "safe";
 }
 
-function getPrimaryRecommendation(
-  item: ApiItem,
-  actionLevel: ActionLevel,
-  context: VerdictContext
-): string {
-  return getRecommendations(item, context)[0] ?? ACTION_COPY[actionLevel].fallbackRecommendation;
-}
-
-function getConfidenceNote(confidence: ConfidenceLevel | null): string {
-  if (confidence === "HIGH") {
-    return "High-confidence signals support this verdict.";
-  }
-  if (confidence === "MEDIUM") {
-    return "Signal confidence is moderate, so context still matters.";
-  }
-  if (confidence === "LOW") {
-    return "Signals are limited, so verify before acting.";
-  }
-  return "No confidence label was returned for this result.";
-}
-
 function getPlainLanguageSummary(item: ApiItem, context: VerdictContext): string {
   const actionLevel = getActionLevel(item);
+  const responseSummary = getString(item.family?.summary) ?? getString(item.result.summary);
+  if (responseSummary) {
+    return responseSummary;
+  }
 
   if (isEmailContext(context)) {
     if (actionLevel === "safe") {
@@ -301,46 +299,24 @@ function getPlainLanguageSummary(item: ApiItem, context: VerdictContext): string
     return "The QR code leads to a destination that looks unsafe.";
   }
 
-  if (actionLevel === "safe") {
-    return "This destination did not show strong warning signs in this scan.";
-  }
-  if (actionLevel === "caution") {
-    return "This destination has some warning signs, so verify it before opening.";
-  }
-  if (actionLevel === "avoid") {
-    return "This destination shows strong warning signs and should be avoided for now.";
-  }
-  return "This destination looks unsafe and should be blocked or reported.";
+  return ACTION_COPY[actionLevel].fallbackExplanation;
 }
 
-function getVerdictDetail(actionLevel: ActionLevel, context: VerdictContext): string {
-  if (isEmailContext(context)) {
-    if (actionLevel === "safe") {
-      return "The visible sender checks look normal enough that this message does not need an immediate block.";
-    }
-    if (actionLevel === "caution") {
-      return "Some sender checks are missing or weak, so this message deserves a second look.";
-    }
-    if (actionLevel === "avoid") {
-      return "Several sender checks failed or degraded, which raises spoofing risk.";
-    }
-    return "Multiple sender checks failed, which is common in spoofed or malicious messages.";
+function getDisplayReasons(item: ApiItem, context: VerdictContext): string[] {
+  const actionLevel = getActionLevel(item);
+  const reasons = getReasons(item, context);
+  if (reasons.length > 0) {
+    return reasons;
   }
+  return ACTION_COPY[actionLevel].fallbackReasons.slice(0, 3);
+}
 
-  if (isQrContext(context)) {
-    if (actionLevel === "safe") {
-      return "The QR code resolved cleanly and the visible destination did not trigger major warnings.";
-    }
-    if (actionLevel === "caution") {
-      return "The QR code resolved, but the destination still deserves a quick verification step.";
-    }
-    if (actionLevel === "avoid") {
-      return "The QR code resolves to a destination that should not be trusted casually.";
-    }
-    return "The QR code resolves to a destination with high-risk signals.";
-  }
-
-  return ACTION_COPY[actionLevel].detail;
+function getNextActions(item: ApiItem, context: VerdictContext): string[] {
+  const actionLevel = getActionLevel(item);
+  return dedupeStrings([
+    ...getRecommendations(item, context),
+    ...ACTION_COPY[actionLevel].fallbackRecommendations
+  ]).slice(0, 3);
 }
 
 function formatLabelList(values: string[]): string {
@@ -381,77 +357,78 @@ function MetricCard({ label, value }: { label: string; value: string }) {
   );
 }
 
+function VerdictIcon({ actionLevel }: { actionLevel: ActionLevel }) {
+  const iconLabel = actionLevel === "safe" ? "OK" : actionLevel === "caution" ? "!" : "!";
+
+  return (
+    <span className={`verdictIcon verdictIcon-${actionLevel}`} aria-hidden="true">
+      {iconLabel}
+    </span>
+  );
+}
+
 function VerdictCard({ item, context }: { item: ApiItem; context: VerdictContext }) {
-  const riskScore = getRiskScore(item);
-  const confidence = getConfidence(item);
   const actionLevel = getActionLevel(item);
-  const primaryRecommendation = getPrimaryRecommendation(item, actionLevel, context);
   const actionCopy = ACTION_COPY[actionLevel];
 
   return (
     <section className={`verdictCard verdictCard-${actionLevel}`} data-testid="analyze-verdict-card">
-      <div className="verdictHeader">
-        <div>
-          <p className="eyebrow">Primary verdict</p>
-          <h3>{actionCopy.title}</h3>
-        </div>
-        <span className={`actionPill actionPill-${actionLevel}`}>Action: {actionCopy.badge}</span>
+      <VerdictIcon actionLevel={actionLevel} />
+      <div className="verdictMainCopy">
+        <h2>Verdict</h2>
+        <p className="verdictStatus">{actionCopy.verdictLabel}</p>
+        <p className="verdictSummary">{getPlainLanguageSummary(item, context)}</p>
       </div>
-
-      <p className="verdictSummary">{getPlainLanguageSummary(item, context)}</p>
-      <p className="muted compactText">{getVerdictDetail(actionLevel, context)}</p>
-
-      <div className="verdictPrimaryAction">
-        <span className="metricLabel">Recommended next step</span>
-        <strong>{primaryRecommendation}</strong>
+      <div className="riskLevelBlock" aria-label={`Risk level ${actionCopy.riskLabel}`}>
+        <span>Risk level</span>
+        <strong
+          className={`riskPill riskPill-${actionLevel}`}
+          data-testid="analyze-risk-pill"
+        >
+          Risk level {actionCopy.riskLabel}
+        </strong>
       </div>
-
-      <div className="badgeRow">
-        <span className="badge">Subject: {item.subject}</span>
-        <span className="badge">Risk: {riskScore !== null ? String(riskScore) : "-"}</span>
-        <span className="badge">Findings: {String(getFindingCount(item))}</span>
-        <span className="badge">Flow: {context.flow}</span>
-        <span className="badge">Confidence: {confidence ?? "Not provided"}</span>
-      </div>
-
-      <p className="verdictConfidence">{getConfidenceNote(confidence)}</p>
     </section>
   );
 }
 
-function WhyPanel({ item, context }: { item: ApiItem; context: VerdictContext }) {
-  const actionLevel = getActionLevel(item);
-  const reasons = getReasons(item, context);
-  const recommendations = getRecommendations(item, context);
-  const nextSteps =
-    recommendations.length > 0
-      ? recommendations
-      : [ACTION_COPY[actionLevel].fallbackRecommendation];
+function KeyReasonsCard({ item, context }: { item: ApiItem; context: VerdictContext }) {
+  const reasons = getDisplayReasons(item, context);
 
   return (
-    <div className="resultList">
-      <section className="miniCard">
-        <h3>Why this verdict</h3>
-        {reasons.length > 0 ? (
-          <ol className="rankedList">
-            {reasons.map((reason) => (
-              <li key={reason}>{reason}</li>
-            ))}
-          </ol>
-        ) : (
-          <p className="muted">No reason strings were returned for this item.</p>
-        )}
-      </section>
+    <section className="resultInfoCard keyReasonsCard" data-testid="analyze-key-reasons">
+      <div className="resultInfoHeader">
+        <span className="resultInfoIcon" aria-hidden="true">
+          !
+        </span>
+        <h2>Key reasons</h2>
+      </div>
+      <ul className="reasonList">
+        {reasons.map((reason) => (
+          <li key={reason}>{reason}</li>
+        ))}
+      </ul>
+    </section>
+  );
+}
 
-      <section className="miniCard">
-        <h3>Next actions</h3>
-        <ul className="cleanList">
-          {nextSteps.map((recommendation) => (
-            <li key={recommendation}>{recommendation}</li>
-          ))}
-        </ul>
-      </section>
-    </div>
+function NextActionsCard({ item, context }: { item: ApiItem; context: VerdictContext }) {
+  const nextActions = getNextActions(item, context);
+
+  return (
+    <section className="resultInfoCard nextActionsCard" data-testid="analyze-next-actions">
+      <div className="resultInfoHeader">
+        <span className="resultInfoIcon resultInfoIconQuestion" aria-hidden="true">
+          ?
+        </span>
+        <h2>What to do next</h2>
+      </div>
+      <ul className="nextActionList">
+        {nextActions.map((recommendation) => (
+          <li key={recommendation}>{recommendation}</li>
+        ))}
+      </ul>
+    </section>
   );
 }
 
@@ -717,63 +694,118 @@ function EvidencePanel({ rows }: { rows: ApiAnalystEvidenceRow[] }) {
   );
 }
 
-function AnalystFallback({ response }: { response: ApiWrappedResponse }) {
-  const items = getResponseItems(response);
-  const primaryItem = getPrimaryItem(response);
+function ContractSummary({
+  response,
+  primaryItem
+}: {
+  response: ApiWrappedResponse;
+  primaryItem: ApiItem;
+}) {
+  return (
+    <section className="miniCard">
+      <h3>Contract summary</h3>
+      <div className="summaryGrid">
+        <MetricCard label="Schema" value={response.schema_version} />
+        <MetricCard label="Flow" value={response.flow} />
+        <MetricCard label="Mode" value={response.mode} />
+        <MetricCard label="Items" value={String(response.item_count)} />
+        <MetricCard label="Input type" value={response.input_type} />
+        <MetricCard label="Primary subject" value={primaryItem.subject} />
+      </div>
+    </section>
+  );
+}
+
+function PrimaryItemSnapshot({ item }: { item: ApiItem }) {
+  return (
+    <section className="miniCard">
+      <h3>Primary item snapshot</h3>
+      <div className="summaryGrid">
+        <MetricCard label="Severity" value={getSeverity(item)} />
+        <MetricCard
+          label="Risk"
+          value={getRiskScore(item) !== null ? String(getRiskScore(item)) : "-"}
+        />
+        <MetricCard label="Findings" value={String(getFindingCount(item))} />
+        <MetricCard label="Confidence" value={getConfidence(item) ?? "-"} />
+      </div>
+      <p className="compactText">{getSummary(item)}</p>
+    </section>
+  );
+}
+
+function ReturnedSubjects({ items }: { items: ApiItem[] }) {
+  if (items.length <= 1) {
+    return null;
+  }
 
   return (
-    <div className="resultList">
-      <section className="miniCard">
-        <h3>Contract summary</h3>
-        <div className="summaryGrid">
-          <MetricCard label="Schema" value={response.schema_version} />
-          <MetricCard label="Flow" value={response.flow} />
-          <MetricCard label="Mode" value={response.mode} />
-          <MetricCard label="Items" value={String(response.item_count)} />
-          <MetricCard label="Input type" value={response.input_type} />
-          <MetricCard label="Primary subject" value={primaryItem?.subject ?? "-"} />
-        </div>
-      </section>
+    <section className="miniCard">
+      <h3>Returned subjects</h3>
+      <ul className="cleanList">
+        {items.map((item) => (
+          <li key={item.subject}>
+            {item.subject} ({getSeverity(item)}, risk {getRiskScore(item) ?? "-"})
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}
 
-      {primaryItem ? (
-        <section className="miniCard">
-          <h3>Primary item snapshot</h3>
-          <div className="summaryGrid">
-            <MetricCard label="Severity" value={getSeverity(primaryItem)} />
-            <MetricCard
-              label="Risk"
-              value={getRiskScore(primaryItem) !== null ? String(getRiskScore(primaryItem)) : "-"}
-            />
-            <MetricCard label="Findings" value={String(getFindingCount(primaryItem))} />
-            <MetricCard
-              label="Confidence"
-              value={getString(primaryItem.family?.signal_confidence) ?? "-"}
-            />
-          </div>
-          <p className="compactText">{getSummary(primaryItem)}</p>
-        </section>
-      ) : null}
+function RawResponseDetails({ response }: { response: ApiWrappedResponse }) {
+  return (
+    <details className="rawResponseDetails">
+      <summary>Raw response</summary>
+      <pre>{asPrettyJson(response)}</pre>
+    </details>
+  );
+}
 
-      <section className="miniCard">
-        <h3>Returned subjects</h3>
-        {items.length > 0 ? (
-          <ul className="cleanList">
-            {items.map((item) => (
-              <li key={item.subject}>
-                {item.subject} ({getSeverity(item)}, risk {getRiskScore(item) ?? "-"})
-              </li>
-            ))}
-          </ul>
+function TechnicalDetails({
+  response,
+  primaryItem,
+  items
+}: {
+  response: ApiWrappedResponse;
+  primaryItem: ApiItem;
+  items: ApiItem[];
+}) {
+  const analyst = response.input_type === "url" ? primaryItem.analyst : undefined;
+
+  return (
+    <details className="technicalDetails" data-testid="analyze-technical-details">
+      <summary>
+        <span>Evidence / technical details</span>
+        <span className="technicalDetailsChevron" aria-hidden="true">
+          v
+        </span>
+      </summary>
+      <div className="technicalDetailsBody">
+        <ContractSummary response={response} primaryItem={primaryItem} />
+        <PrimaryItemSnapshot item={primaryItem} />
+        {analyst ? (
+          <>
+            <DomainAnatomy anatomy={analyst.domain_anatomy} />
+            {analyst.redirect_trace ? <RedirectPathView trace={analyst.redirect_trace} /> : null}
+            {analyst.suppression_trace ? (
+              <SuppressionTracePanel trace={analyst.suppression_trace} />
+            ) : null}
+            <EvidencePanel rows={analyst.evidence_rows} />
+          </>
         ) : (
-          <p className="muted">No item subjects were returned.</p>
+          <section className="miniCard">
+            <h3>Structured evidence</h3>
+            <p className="muted">
+              No URL analyst evidence was returned for this result. The raw response remains
+              available below for debugging.
+            </p>
+          </section>
         )}
-      </section>
-
-      <section className="miniCard">
-        <h3>Raw JSON</h3>
-        <pre>{asPrettyJson(response)}</pre>
-      </section>
-    </div>
+        <ReturnedSubjects items={items} />
+        <RawResponseDetails response={response} />
+      </div>
+    </details>
   );
 }
 
@@ -792,90 +824,12 @@ export function QuickResult({ response }: { response: ApiWrappedResponse }) {
   return (
     <>
       <VerdictCard item={primaryItem} context={context} />
-      <WhyPanel item={primaryItem} context={context} />
-
-      {items.length > 1 ? (
-        <section className="miniCard">
-          <h3>Additional decoded items</h3>
-          <div className="resultListCompact">
-            {items.slice(1).map((item) => (
-              <article className="miniCard insetCard" key={item.subject}>
-                <strong>{item.subject}</strong>
-                <p className="muted compactText">{getSummary(item)}</p>
-                <div className="badgeRow">
-                  <span className="badge">Action: {ACTION_COPY[getActionLevel(item)].badge}</span>
-                  <span className="badge">
-                    Risk: {getRiskScore(item) !== null ? String(getRiskScore(item)) : "-"}
-                  </span>
-                </div>
-              </article>
-            ))}
-          </div>
-        </section>
-      ) : null}
+      <div className="resultInfoGrid">
+        <KeyReasonsCard item={primaryItem} context={context} />
+        <NextActionsCard item={primaryItem} context={context} />
+      </div>
+      <TechnicalDetails response={response} primaryItem={primaryItem} items={items} />
     </>
-  );
-}
-
-export function AnalystResult({ response }: { response: ApiWrappedResponse }) {
-  const items = getResponseItems(response);
-  const primaryItem = getPrimaryItem(response);
-  const analyst = response.input_type === "url" ? primaryItem?.analyst : undefined;
-
-  if (!primaryItem) {
-    return <p className="muted">The API returned no items.</p>;
-  }
-
-  if (!analyst) {
-    return <AnalystFallback response={response} />;
-  }
-
-  return (
-    <div className="resultList">
-      <section className="miniCard">
-        <h3>Contract summary</h3>
-        <div className="summaryGrid">
-          <MetricCard label="Schema" value={response.schema_version} />
-          <MetricCard label="Flow" value={response.flow} />
-          <MetricCard label="Mode" value={response.mode} />
-          <MetricCard label="Items" value={String(response.item_count)} />
-          <MetricCard label="Input type" value={response.input_type} />
-          <MetricCard label="Primary subject" value={primaryItem.subject} />
-        </div>
-      </section>
-
-      <section className="miniCard">
-        <h3>Primary item snapshot</h3>
-        <div className="summaryGrid">
-          <MetricCard label="Severity" value={getSeverity(primaryItem)} />
-          <MetricCard
-            label="Risk"
-            value={getRiskScore(primaryItem) !== null ? String(getRiskScore(primaryItem)) : "-"}
-          />
-          <MetricCard label="Findings" value={String(getFindingCount(primaryItem))} />
-          <MetricCard label="Confidence" value={getConfidence(primaryItem) ?? "-"} />
-        </div>
-        <p className="compactText">{getSummary(primaryItem)}</p>
-      </section>
-
-      <DomainAnatomy anatomy={analyst.domain_anatomy} />
-      {analyst.redirect_trace ? <RedirectPathView trace={analyst.redirect_trace} /> : null}
-      {analyst.suppression_trace ? <SuppressionTracePanel trace={analyst.suppression_trace} /> : null}
-      <EvidencePanel rows={analyst.evidence_rows} />
-
-      {items.length > 1 ? (
-        <section className="miniCard">
-          <h3>Returned subjects</h3>
-          <ul className="cleanList">
-            {items.map((item) => (
-              <li key={item.subject}>
-                {item.subject} ({getSeverity(item)}, risk {getRiskScore(item) ?? "-"})
-              </li>
-            ))}
-          </ul>
-        </section>
-      ) : null}
-    </div>
   );
 }
 
@@ -883,13 +837,11 @@ export function EmptyState() {
   return (
     <section className="statusPanel">
       <p className="eyebrow">Ready</p>
-      <h3>Run an analysis from the left panel</h3>
+      <h2>Paste a link or upload a QR image</h2>
       <p className="muted">
-        This workspace always asks the API for family summaries so Quick mode can render a verdict
-        without falling back to raw JSON.
+        The result will show a clear verdict, key reasons, next steps, and optional technical
+        details after analysis finishes.
       </p>
     </section>
   );
 }
-
-

--- a/ui/app/analyze/result-panels.tsx
+++ b/ui/app/analyze/result-panels.tsx
@@ -379,13 +379,15 @@ function VerdictCard({ item, context }: { item: ApiItem; context: VerdictContext
         <p className="verdictStatus">{actionCopy.verdictLabel}</p>
         <p className="verdictSummary">{getPlainLanguageSummary(item, context)}</p>
       </div>
-      <div className="riskLevelBlock" aria-label={`Risk level ${actionCopy.riskLabel}`}>
+      <div className="riskLevelBlock">
         <span>Risk level</span>
         <strong
+          aria-label={`Risk level ${actionCopy.riskLabel}`}
           className={`riskPill riskPill-${actionLevel}`}
           data-testid="analyze-risk-pill"
+          role="status"
         >
-          Risk level {actionCopy.riskLabel}
+          {actionCopy.riskLabel}
         </strong>
       </div>
     </section>

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -263,114 +263,273 @@ pre {
 }
 
 .verdictCard {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: 24px;
+  align-items: center;
+  min-height: 144px;
   border: 1px solid var(--border);
-  border-radius: 18px;
-  padding: 18px;
-  background: linear-gradient(180deg, var(--accent), #ffffff 72%);
-  margin-bottom: 14px;
+  border-radius: 12px;
+  padding: 26px 28px;
+  background: #ffffff;
+  margin-bottom: 10px;
   box-shadow: 0 14px 30px rgba(20, 32, 56, 0.08);
 }
 
 .verdictCard-safe {
-  background: linear-gradient(180deg, #eef9f1, #ffffff 72%);
+  border-color: #a8d8b5;
+  background: linear-gradient(90deg, #f3fff5, #ffffff 68%);
 }
 
 .verdictCard-caution {
-  background: linear-gradient(180deg, #fff8eb, #ffffff 72%);
+  border-color: #f0c36f;
+  background: linear-gradient(90deg, #fff9ed, #ffffff 68%);
 }
 
 .verdictCard-avoid {
-  background: linear-gradient(180deg, #fff2eb, #ffffff 72%);
+  border-color: #f3aaa3;
+  background: linear-gradient(90deg, #fff6f3, #ffffff 68%);
 }
 
 .verdictCard-block {
-  background: linear-gradient(180deg, #fff1f5, #ffffff 72%);
+  border-color: #ef9fb3;
+  background: linear-gradient(90deg, #fff3f6, #ffffff 68%);
 }
 
-.verdictHeader {
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
-  align-items: flex-start;
-  flex-wrap: wrap;
+.verdictIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 72px;
+  height: 72px;
+  border: 4px solid currentColor;
+  border-radius: 20px;
+  font-size: 2rem;
+  font-weight: 900;
+  line-height: 1;
 }
 
-.verdictHeader h3 {
+.verdictIcon-safe {
+  color: #17803f;
+}
+
+.verdictIcon-caution {
+  color: #b86a00;
+}
+
+.verdictIcon-avoid {
+  color: #dc2626;
+}
+
+.verdictIcon-block {
+  color: #be123c;
+}
+
+.verdictMainCopy {
+  min-width: 0;
+}
+
+.verdictMainCopy h2,
+.resultInfoHeader h2 {
   margin: 0;
-  font-size: 1.7rem;
+  color: #07122e;
+  font-size: 1rem;
+  line-height: 1.2;
+}
+
+.verdictStatus {
+  margin: 10px 0 0;
+  font-size: 2rem;
+  font-weight: 800;
+  line-height: 1.08;
+}
+
+.verdictCard-safe .verdictStatus {
+  color: var(--safe-ink);
+}
+
+.verdictCard-caution .verdictStatus {
+  color: var(--caution-ink);
+}
+
+.verdictCard-avoid .verdictStatus {
+  color: #dc2626;
+}
+
+.verdictCard-block .verdictStatus {
+  color: var(--block-ink);
 }
 
 .verdictSummary {
-  margin-bottom: 0;
-  font-size: 1.05rem;
-  line-height: 1.5;
-}
-
-.verdictPrimaryAction {
-  margin-top: 16px;
-  padding: 14px;
-  border-radius: 14px;
-  background: rgba(255, 255, 255, 0.82);
-  border: 1px solid rgba(20, 32, 56, 0.08);
-}
-
-.verdictPrimaryAction strong {
-  display: block;
-  margin-top: 4px;
+  max-width: 620px;
+  margin: 12px 0 0;
   font-size: 1.02rem;
-  line-height: 1.45;
+  line-height: 1.55;
 }
 
-.verdictConfidence {
-  margin: 14px 0 0;
-  color: var(--muted);
-  font-size: 0.95rem;
+.riskLevelBlock {
+  display: grid;
+  justify-items: start;
+  gap: 10px;
+  min-width: 160px;
+  color: #07122e;
+  font-weight: 650;
 }
 
-.actionPill {
+.riskPill {
   display: inline-flex;
   align-items: center;
   border-radius: 999px;
-  padding: 9px 12px;
-  font-size: 0.84rem;
+  padding: 9px 14px;
+  font-size: 0.95rem;
   font-weight: 800;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  white-space: nowrap;
 }
 
-.actionPill-safe {
+.riskPill-safe {
   background: var(--safe-bg);
   color: var(--safe-ink);
 }
 
-.actionPill-caution {
+.riskPill-caution {
   background: var(--caution-bg);
   color: var(--caution-ink);
 }
 
-.actionPill-avoid {
-  background: var(--avoid-bg);
-  color: var(--avoid-ink);
+.riskPill-avoid {
+  background: #ffe1df;
+  color: #dc2626;
 }
 
-.actionPill-block {
+.riskPill-block {
   background: var(--block-bg);
   color: var(--block-ink);
 }
 
-.resultList,
+.resultInfoGrid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
+}
+
+.resultInfoCard {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 20px;
+  background: #ffffff;
+  box-shadow: 0 10px 24px rgba(20, 32, 56, 0.06);
+}
+
+.resultInfoHeader {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.resultInfoIcon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 2px solid #dc2626;
+  border-radius: 999px;
+  color: #dc2626;
+  font-weight: 900;
+  line-height: 1;
+}
+
+.resultInfoIconQuestion {
+  border-color: #0b5cff;
+  color: #0b5cff;
+}
+
+.reasonList,
+.nextActionList,
+.cleanList {
+  margin: 0;
+  padding-left: 18px;
+}
+
+.reasonList,
+.nextActionList {
+  display: grid;
+  gap: 12px;
+  color: #101a33;
+  line-height: 1.45;
+}
+
+.reasonList li::marker {
+  color: #dc2626;
+}
+
+.nextActionList li::marker {
+  color: #0b5cff;
+}
+
+.technicalDetails {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: #ffffff;
+  box-shadow: 0 10px 24px rgba(20, 32, 56, 0.05);
+  overflow: hidden;
+}
+
+.technicalDetails summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 56px;
+  padding: 0 18px;
+  color: #07122e;
+  font-weight: 800;
+  cursor: pointer;
+  list-style: none;
+}
+
+.technicalDetails summary::-webkit-details-marker,
+.rawResponseDetails summary::-webkit-details-marker {
+  display: none;
+}
+
+.technicalDetailsChevron {
+  color: var(--muted);
+  transition: transform 160ms ease;
+}
+
+.technicalDetails[open] .technicalDetailsChevron {
+  transform: rotate(180deg);
+}
+
+.technicalDetailsBody {
+  display: grid;
+  gap: 12px;
+  padding: 0 16px 16px;
+}
+
+.rawResponseDetails {
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  background: #f8fafc;
+}
+
+.rawResponseDetails summary {
+  padding: 12px 14px;
+  color: var(--muted);
+  font-weight: 700;
+  cursor: pointer;
+  list-style: none;
+}
+
+.rawResponseDetails pre {
+  margin: 0 12px 12px;
+}
+
 .resultListCompact {
   display: grid;
   gap: 12px;
-}
-
-.rankedList {
-  margin: 0;
-  padding-left: 22px;
-}
-
-.rankedList li + li {
-  margin-top: 10px;
 }
 
 .miniCard {
@@ -378,10 +537,6 @@ pre {
   border-radius: 12px;
   padding: 14px;
   background: #ffffff;
-}
-
-.insetCard {
-  background: #fbfcfe;
 }
 
 .badgeRow {
@@ -401,11 +556,6 @@ pre {
   background: #f3f7fb;
   font-size: 0.85rem;
   font-weight: 600;
-}
-
-.cleanList {
-  margin: 0;
-  padding-left: 18px;
 }
 
 .statusPanel {
@@ -652,6 +802,10 @@ pre {
     grid-template-columns: 1fr;
   }
 
+  .resultInfoGrid {
+    grid-template-columns: 1fr;
+  }
+
   .analyzePrimaryButton {
     width: 100%;
   }
@@ -670,8 +824,18 @@ pre {
     grid-template-columns: 1fr;
   }
 
-  .verdictHeader h3 {
-    font-size: 1.4rem;
+  .verdictCard {
+    grid-template-columns: 1fr;
+    gap: 16px;
+    padding: 22px;
+  }
+
+  .verdictStatus {
+    font-size: 1.65rem;
+  }
+
+  .riskLevelBlock {
+    min-width: 0;
   }
 }
 

--- a/ui/e2e/analyze.smoke.spec.ts
+++ b/ui/e2e/analyze.smoke.spec.ts
@@ -38,8 +38,10 @@ test("validates empty and mixed input without clearing a successful URL result",
   await page.getByLabel("URL").fill("https://example.com");
   await page.getByRole("button", { name: "Analyze" }).click();
   await expect(page.getByTestId("analyze-verdict-card")).toBeVisible();
-  await expect(page.getByText("Subject: https://example.com")).toBeVisible();
-  await expect(page.getByText("Flow: analyze")).toBeVisible();
+  await expect(page.getByTestId("analyze-risk-pill")).toBeVisible();
+  await expect(page.getByTestId("analyze-key-reasons")).toBeVisible();
+  await expect(page.getByTestId("analyze-next-actions")).toBeVisible();
+  await expect(page.getByTestId("analyze-technical-details")).toHaveJSProperty("open", false);
 
   await page.getByLabel("QR image (optional)").setInputFiles(QR_FIXTURE);
   await page.getByRole("button", { name: "Analyze" }).click();

--- a/ui/e2e/analyze.verdict.spec.ts
+++ b/ui/e2e/analyze.verdict.spec.ts
@@ -277,7 +277,9 @@ test("URL analysis renders the simplified verdict hierarchy with collapsed evide
   await expect(verdictCard.getByRole("heading", { name: "Verdict" })).toBeVisible();
   await expect(verdictCard.getByText("Suspicious", { exact: true })).toBeVisible();
 
-  await expect(page.getByTestId("analyze-risk-pill")).toHaveText("Risk level High");
+  const riskPill = page.getByTestId("analyze-risk-pill");
+  await expect(riskPill).toHaveText("High");
+  await expect(riskPill).toHaveAccessibleName("Risk level High");
 
   const keyReasons = page.getByTestId("analyze-key-reasons");
   await expect(keyReasons.getByRole("heading", { name: "Key reasons" })).toBeVisible();
@@ -312,7 +314,9 @@ test("safe action display maps to Safe and Low without showing email tabs", asyn
 
   const verdictCard = page.getByTestId("analyze-verdict-card");
   await expect(verdictCard.getByText("Safe", { exact: true })).toBeVisible();
-  await expect(page.getByTestId("analyze-risk-pill")).toHaveText("Risk level Low");
+  const riskPill = page.getByTestId("analyze-risk-pill");
+  await expect(riskPill).toHaveText("Low");
+  await expect(riskPill).toHaveAccessibleName("Risk level Low");
   await expect(page.getByTestId("analyze-key-reasons")).toBeVisible();
   await expect(page.getByTestId("analyze-next-actions")).toBeVisible();
 });

--- a/ui/e2e/analyze.verdict.spec.ts
+++ b/ui/e2e/analyze.verdict.spec.ts
@@ -1,7 +1,4 @@
-import { expect, test, type Locator, type Page } from "@playwright/test";
-
-const OBSOLETE_ANALYZE_VERDICT_REASON =
-  "Temporarily disabled after M1 shell/input simplification; rewritten in Issue #20.";
+import { expect, test, type Page } from "@playwright/test";
 
 const SAFE_URL_RESPONSE = {
   schema_version: "2.0",
@@ -59,7 +56,7 @@ const SAFE_URL_RESPONSE = {
   }
 } as const;
 
-const ANALYST_URL_RESPONSE = {
+const SUSPICIOUS_URL_RESPONSE = {
   schema_version: "2.0",
   flow: "analyze",
   mode: "single",
@@ -243,174 +240,79 @@ const ANALYST_URL_RESPONSE = {
   }
 } as const;
 
-const BLOCK_EMAIL_RESPONSE = {
-  schema_version: "2.0",
-  flow: "analyze",
-  mode: "single",
-  input_type: "email_headers",
-  item_count: 1,
-  item: {
-    subject: "finance-alert",
-    result: {
-      input: {
-        input_type: "email_headers",
-        content: "Authentication-Results: mx; spf=fail; dkim=fail; dmarc=fail",
-        metadata: {}
-      },
-      findings: [
-        {
-          module: "email_auth",
-          category: "EML301_DMARC_FAIL",
-          severity: "CRITICAL",
-          confidence: "HIGH",
-          risk_score: 95,
-          title: "DMARC policy check failed",
-          explanation: "DMARC status indicates a fail or policy error.",
-          family_explanation: "The sender's domain policy check (DMARC) failed.",
-          evidence: [],
-          recommendations: ["Do not act on sensitive requests until verified independently."]
-        },
-        {
-          module: "email_auth",
-          category: "EML201_DKIM_FAIL",
-          severity: "HIGH",
-          confidence: "HIGH",
-          risk_score: 80,
-          title: "DKIM signature validation failed",
-          explanation: "DKIM status indicates a failed or broken signature.",
-          family_explanation: "The email's signed authenticity check (DKIM) did not pass.",
-          evidence: [],
-          recommendations: ["Treat the message as suspicious until independently verified."]
-        }
-      ],
-      overall_risk: 95,
-      overall_severity: "CRITICAL",
-      summary:
-        "High-risk email-authentication warning. Do not trust links or urgent requests until independently verified.",
-      analyzed_at: "2026-03-06T00:00:00Z"
-    },
-    family: {
-      risk_score: 95,
-      severity: "CRITICAL",
-      summary:
-        "High-risk email-authentication warning. Do not trust links or urgent requests until independently verified.",
-      signal_confidence: "HIGH",
-      reasons: [
-        "The sender's domain policy check (DMARC) failed.",
-        "The email's signed authenticity check (DKIM) did not pass."
-      ],
-      recommendations: [
-        "Do not act on sensitive requests until verified independently.",
-        "Treat the message as suspicious until independently verified."
-      ]
-    }
-  }
-} as const;
-
 async function gotoAnalyze(page: Page) {
   await page.addInitScript(() => {
     window.localStorage.clear();
   });
   await page.goto("/analyze");
-  await expect(page.getByRole("heading", { name: "Unified Analyze Workspace" })).toBeVisible();
+  await expect(
+    page.getByRole("heading", { name: "Analyze a suspicious link or QR code" })
+  ).toBeVisible();
 }
 
-function panelByHeading(page: Page, headingName: string): Locator {
-  return page.getByRole("heading", { name: headingName }).locator("xpath=ancestor::section[1]");
+async function mockAnalyzeResponse(page: Page, response: object) {
+  await page.route("**/api/v2/analyze", async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify(response)
+    });
+  });
 }
 
-test.fixme(true, OBSOLETE_ANALYZE_VERDICT_REASON);
+async function submitUrl(page: Page, url: string) {
+  await page.getByLabel("URL").fill(url);
+  await page.getByRole("button", { name: "Analyze" }).click();
+}
 
-test("quick mode presents a safe decision without analyst-only details", async ({ page }) => {
-  await page.route("**/api/v2/analyze", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify(SAFE_URL_RESPONSE)
-    });
-  });
-
+test("URL analysis renders the simplified verdict hierarchy with collapsed evidence", async ({
+  page
+}) => {
+  await mockAnalyzeResponse(page, SUSPICIOUS_URL_RESPONSE);
   await gotoAnalyze(page);
-  await page.getByPlaceholder("https://example.com").fill("https://example.com");
-  await page.getByRole("button", { name: "Analyze URL" }).click();
+  await submitUrl(page, "https://login.example.test");
 
-  await expect(page.getByText("Action: Safe")).toBeVisible();
-  await expect(page.getByText("Safe to continue")).toBeVisible();
-  const safeVerdictPanel = panelByHeading(page, "Safe to continue");
-  await expect(
-    page.getByText("This destination did not show strong warning signs in this scan.")
-  ).toBeVisible();
-  await expect(
-    safeVerdictPanel.getByText(
-      "Proceed only if you expected this item, and use trusted bookmarks for sensitive accounts."
-    )
-  ).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Domain anatomy" })).toHaveCount(0);
-  await expect(page.getByRole("heading", { name: "Raw JSON" })).toHaveCount(0);
+  const verdictCard = page.getByTestId("analyze-verdict-card");
+  await expect(verdictCard).toBeVisible();
+  await expect(verdictCard.getByRole("heading", { name: "Verdict" })).toBeVisible();
+  await expect(verdictCard.getByText("Suspicious", { exact: true })).toBeVisible();
+
+  await expect(page.getByTestId("analyze-risk-pill")).toHaveText("Risk level High");
+
+  const keyReasons = page.getByTestId("analyze-key-reasons");
+  await expect(keyReasons.getByRole("heading", { name: "Key reasons" })).toBeVisible();
+  await expect(keyReasons.getByRole("listitem")).toHaveCount(1);
+
+  const nextActions = page.getByTestId("analyze-next-actions");
+  await expect(nextActions.getByRole("heading", { name: "What to do next" })).toBeVisible();
+  await expect(nextActions.getByRole("listitem")).toHaveCount(3);
+
+  const technicalDetails = page.getByTestId("analyze-technical-details");
+  await expect(technicalDetails).toBeVisible();
+  await expect(technicalDetails).toHaveJSProperty("open", false);
+  await expect(technicalDetails.locator("h3", { hasText: "Domain anatomy" })).toBeHidden();
+
+  await technicalDetails.locator("summary").first().click();
+  await expect(technicalDetails).toHaveJSProperty("open", true);
+  await expect(technicalDetails.locator("h3", { hasText: "Domain anatomy" })).toBeVisible();
+  await expect(technicalDetails.locator("h3", { hasText: "Redirect path" })).toBeVisible();
+  await expect(technicalDetails.locator("h3", { hasText: "Suppression trace" })).toBeVisible();
+  await expect(technicalDetails.locator("h3", { hasText: "Evidence panel" })).toBeVisible();
 });
 
-test("analyst mode renders URL-specific panels from structured v2 payloads", async ({ page }) => {
-  await page.route("**/api/v2/analyze", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify(ANALYST_URL_RESPONSE)
-    });
-  });
-
+test("safe action display maps to Safe and Low without showing email tabs", async ({ page }) => {
+  await mockAnalyzeResponse(page, SAFE_URL_RESPONSE);
   await gotoAnalyze(page);
-  await page.getByPlaceholder("https://example.com").fill("https://login.example.test");
-  await page.getByRole("button", { name: "Analyze URL" }).click();
-  await page.getByRole("tab", { name: "Analyst" }).click();
 
-  await expect(page.getByRole("heading", { name: "Contract summary" })).toBeVisible();
+  await expect(page.getByRole("tab", { name: "Email" })).toHaveCount(0);
+  await expect(page.getByLabel("Email headers")).toHaveCount(0);
+  await expect(page.getByRole("button", { name: /Analyze email/i })).toHaveCount(0);
 
-  const domainPanel = panelByHeading(page, "Domain anatomy");
-  await expect(domainPanel).toBeVisible();
-  await expect(
-    domainPanel
-      .locator(".metricCard")
-      .filter({ hasText: "Hostname" })
-      .filter({ hasText: "login.example.test" })
-  ).toBeVisible();
+  await submitUrl(page, "https://example.com");
 
-  const redirectPanel = panelByHeading(page, "Redirect path");
-  await expect(redirectPanel).toBeVisible();
-  await expect(redirectPanel.getByText("Cross-domain redirect", { exact: true })).toBeVisible();
-
-  const suppressionPanel = panelByHeading(page, "Suppression trace");
-  await expect(suppressionPanel).toBeVisible();
-  await expect(suppressionPanel.getByText("Suppressed: 1", { exact: true })).toBeVisible();
-
-  const evidencePanel = panelByHeading(page, "Evidence panel");
-  await expect(evidencePanel).toBeVisible();
-  await expect(
-    evidencePanel.getByText("Suspicious brand token appears in a subdomain", { exact: true })
-  ).toBeVisible();
-  await expect(evidencePanel.getByRole("button", { name: "redirect" })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Raw JSON" })).toHaveCount(0);
-});
-
-test("analyst mode keeps email on the raw-details fallback", async ({ page }) => {
-  await page.route("**/api/v2/analyze", async (route) => {
-    await route.fulfill({
-      status: 200,
-      contentType: "application/json",
-      body: JSON.stringify(BLOCK_EMAIL_RESPONSE)
-    });
-  });
-
-  await gotoAnalyze(page);
-  await page.getByRole("tab", { name: "Email" }).click();
-  await page.getByLabel("Source label").fill("finance-alert");
-  await page
-    .getByLabel("Email headers")
-    .fill("Authentication-Results: mx; spf=fail; dkim=fail; dmarc=fail");
-  await page.getByRole("button", { name: "Analyze email headers" }).click();
-
-  await expect(page.getByText("Action: Block")).toBeVisible();
-  await page.getByRole("tab", { name: "Analyst" }).click();
-  await expect(page.getByRole("heading", { name: "Contract summary" })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Raw JSON" })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Domain anatomy" })).toHaveCount(0);
+  const verdictCard = page.getByTestId("analyze-verdict-card");
+  await expect(verdictCard.getByText("Safe", { exact: true })).toBeVisible();
+  await expect(page.getByTestId("analyze-risk-pill")).toHaveText("Risk level Low");
+  await expect(page.getByTestId("analyze-key-reasons")).toBeVisible();
+  await expect(page.getByTestId("analyze-next-actions")).toBeVisible();
 });


### PR DESCRIPTION
## Summary

- Reworks Analyze results into the simplified M1 hierarchy:
  - Verdict
  - Risk level
  - Plain-English explanation
  - Key reasons
  - What to do next
  - Collapsed Evidence / technical details
- Preserves existing action/severity derivation and maps display labels:
  - safe -> Safe / Low
  - caution -> Caution / Medium
  - avoid -> Suspicious / High
  - block -> Dangerous / Critical
- Repurposes analyst/evidence panels inside the collapsed technical details accordion.
- Removes now-dead exported AnalystResult surface.
- Rewrites analyze.verdict.spec.ts for the simplified result hierarchy.
- Updates smoke expectations for moved technical details.

Closes #20.

## Validation

- npm run lint
- npm run typecheck
- npm run build
- npm run smoke:e2e
- npx playwright test e2e/analyze.verdict.spec.ts
- npm run smoke:api
- git diff --check

Note: additional in-app browser visual verification was attempted but the MCP browser profile was locked. Playwright e2e coverage passed against the local UI and API.