### PR TITLE
ux: harden Analyze states and accessibility

### DIFF
--- a/ui/app/analyze/page.tsx
+++ b/ui/app/analyze/page.tsx
@@ -29,11 +29,26 @@ interface RunState {
   lastSubmission: Submission | null;
 }
 
+const QR_ERROR_MESSAGES: Record<string, string> = {
+  QRC_DECODER_UNAVAILABLE:
+    "QR scanning is not available in this environment. Paste the URL from the QR code instead.",
+  QRC_MULTIPART_UNAVAILABLE:
+    "QR image uploads are not available in this environment. Paste the URL from the QR code instead.",
+  QRC_NO_URL_PAYLOADS:
+    "The QR image was read, but it did not contain a web URL. Upload a QR code with an http or https link, or paste the URL."
+};
+
 function formatRequestError(error: unknown): string {
   if (error instanceof ApiRequestError) {
+    if (error.code && QR_ERROR_MESSAGES[error.code]) {
+      return `${QR_ERROR_MESSAGES[error.code]} (${error.code})`;
+    }
     return `${error.message}${error.code ? ` (${error.code})` : ""}`;
   }
   if (error instanceof Error) {
+    if (error.name === "TypeError") {
+      return "Could not reach the analysis API. Confirm it is running and try again.";
+    }
     return error.message;
   }
   return "Unexpected error while calling API.";
@@ -70,6 +85,8 @@ function endpointLabel(submission: Submission | null): string | null {
 
 export default function AnalyzePage() {
   const validationMessageId = useId();
+  const urlInputId = useId();
+  const qrInputId = useId();
   const [url, setUrl] = useState("");
   const [qrFile, setQrFile] = useState<File | null>(null);
   const [validationMessage, setValidationMessage] = useState<string | null>(null);
@@ -82,12 +99,12 @@ export default function AnalyzePage() {
 
   async function executeSubmission(submission: Submission): Promise<void> {
     setValidationMessage(null);
-    setRunState({
+    setRunState((current) => ({
       loading: true,
       error: null,
-      response: null,
+      response: current.response,
       lastSubmission: submission
-    });
+    }));
 
     try {
       let response: ApiWrappedResponse;
@@ -108,12 +125,12 @@ export default function AnalyzePage() {
         lastSubmission: submission
       });
     } catch (error) {
-      setRunState({
+      setRunState((current) => ({
         loading: false,
         error: formatRequestError(error),
-        response: null,
+        response: current.response,
         lastSubmission: submission
-      });
+      }));
     }
   }
 
@@ -166,11 +183,22 @@ export default function AnalyzePage() {
     });
   }
 
+  function onUrlChange(event: ChangeEvent<HTMLInputElement>) {
+    setUrl(event.target.value);
+    if (validationMessage) {
+      setValidationMessage(null);
+    }
+  }
+
   function onQrFileChange(event: ChangeEvent<HTMLInputElement>) {
     setQrFile(event.target.files?.[0] ?? null);
+    if (validationMessage) {
+      setValidationMessage(null);
+    }
   }
 
   const endpoint = endpointLabel(runState.lastSubmission);
+  const validationState = validationMessage ? "true" : undefined;
 
   return (
     <div className="analyzeShell" data-testid="analyze-shell">
@@ -213,17 +241,20 @@ export default function AnalyzePage() {
           onSubmit={onAnalyzeSubmit}
           aria-describedby={validationMessage ? validationMessageId : undefined}
         >
-          <label className="analyzeUrlField">
+          <label className="analyzeUrlField" htmlFor={urlInputId}>
             URL
             <input
+              id={urlInputId}
               value={url}
-              onChange={(event) => setUrl(event.target.value)}
+              onChange={onUrlChange}
               placeholder="https://example.com"
-              aria-invalid={validationMessage ? "true" : undefined}
+              disabled={runState.loading}
+              aria-invalid={validationState}
+              aria-describedby={validationMessage ? validationMessageId : undefined}
             />
           </label>
 
-          <label className="qrUploadField">
+          <label className="qrUploadField" htmlFor={qrInputId}>
             QR image (optional)
             <span className="qrUploadDropzone">
               <span className="qrUploadIcon" aria-hidden="true">
@@ -233,7 +264,15 @@ export default function AnalyzePage() {
                 {qrFile ? qrFile.name : "Click to upload QR image"}
                 <small>PNG, JPG, WEBP up to 5MB</small>
               </span>
-              <input type="file" accept="image/*" onChange={onQrFileChange} />
+              <input
+                id={qrInputId}
+                type="file"
+                accept="image/*"
+                onChange={onQrFileChange}
+                disabled={runState.loading}
+                aria-invalid={validationState}
+                aria-describedby={validationMessage ? validationMessageId : undefined}
+              />
             </span>
           </label>
 
@@ -254,28 +293,35 @@ export default function AnalyzePage() {
           ) : null}
         </form>
 
-        <section className="analyzeResultArea" aria-label="Analysis result">
+        <section
+          className="analyzeResultArea"
+          data-testid="analyze-result-area"
+          aria-label="Analysis result"
+          aria-busy={runState.loading}
+        >
           {endpoint ? <p className="muted compactText">Latest endpoint: {endpoint}</p> : null}
 
           {runState.loading ? (
-            <section className="statusPanel">
+            <section className="statusPanel" role="status" aria-live="polite">
               <p className="eyebrow">In progress</p>
-              <h2>Waiting on the API</h2>
-              <p className="muted">A fresh result will appear here when analysis finishes.</p>
+              <h2>Analyzing this submission</h2>
+              <p className="muted">
+                A fresh result will appear here when analysis finishes.
+                {runState.response ? " The previous result remains below." : ""}
+              </p>
             </section>
           ) : null}
 
           {!runState.loading && runState.error ? (
-            <section className="statusPanel statusPanelError">
+            <section className="statusPanel statusPanelError" role="alert" aria-live="assertive">
               <p className="eyebrow">Error</p>
               <h2>Request failed</h2>
               <p>{runState.error}</p>
+              {runState.response ? <p className="muted">The previous successful result is still shown below.</p> : null}
             </section>
           ) : null}
 
-          {!runState.loading && !runState.error && runState.response ? (
-            <QuickResult response={runState.response} />
-          ) : null}
+          {runState.response ? <QuickResult response={runState.response} /> : null}
 
           {!runState.loading && !runState.error && !runState.response ? <EmptyState /> : null}
         </section>

--- a/ui/app/globals.css
+++ b/ui/app/globals.css
@@ -103,6 +103,18 @@ textarea {
   background: #fff;
 }
 
+input:disabled,
+textarea:disabled {
+  color: var(--muted);
+  background: #f3f6fb;
+  cursor: not-allowed;
+}
+
+input[aria-invalid="true"] {
+  border-color: var(--block-ink);
+  box-shadow: 0 0 0 3px rgba(159, 18, 57, 0.12);
+}
+
 textarea {
   min-height: 170px;
 }
@@ -565,6 +577,10 @@ pre {
   background: #f8fbfc;
 }
 
+.statusPanel h2 {
+  margin: 0;
+}
+
 .statusPanelError {
   border-color: var(--danger-border);
   background: var(--danger-bg);
@@ -736,6 +752,26 @@ pre {
   padding: 0;
   opacity: 0;
   cursor: pointer;
+}
+
+.qrUploadDropzone:has(input:disabled) {
+  color: var(--muted);
+  background: #f3f6fb;
+  cursor: not-allowed;
+}
+
+.qrUploadDropzone:has(input[aria-invalid="true"]) {
+  border-color: var(--block-ink);
+  box-shadow: 0 0 0 3px rgba(159, 18, 57, 0.12);
+}
+
+.qrUploadDropzone:has(input:focus-visible),
+.technicalDetails summary:focus-visible,
+.rawResponseDetails summary:focus-visible,
+.analyzeNavItem:focus-visible,
+.analyzePrimaryButton:focus-visible {
+  outline: 3px solid rgba(11, 92, 255, 0.35);
+  outline-offset: 3px;
 }
 
 .qrUploadDropzone small {

--- a/ui/e2e/analyze.verdict.spec.ts
+++ b/ui/e2e/analyze.verdict.spec.ts
@@ -1,244 +1,264 @@
 import { expect, test, type Page } from "@playwright/test";
 
-const SAFE_URL_RESPONSE = {
-  schema_version: "2.0",
-  flow: "analyze",
-  mode: "single",
-  input_type: "url",
-  item_count: 1,
-  item: {
-    subject: "https://example.com",
-    result: {
-      input: {
-        input_type: "url",
-        content: "https://example.com",
-        metadata: {}
-      },
-      findings: [],
-      overall_risk: 0,
-      overall_severity: "INFO",
-      summary:
-        "No obvious lookalike-link warning signs found. For important accounts, type the website address yourself.",
-      analyzed_at: "2026-03-06T00:00:00Z"
-    },
-    family: {
-      risk_score: 0,
-      severity: "INFO",
-      summary:
-        "No obvious lookalike-link warning signs found. For important accounts, type the website address yourself.",
-      signal_confidence: null,
-      reasons: [],
-      recommendations: []
-    },
-    analyst: {
-      domain_anatomy: {
-        submitted_url: "https://example.com",
-        canonical_url: "https://example.com/",
-        hostname: "example.com",
-        canonical_hostname: "example.com",
-        registrable_domain: "example.com",
-        canonical_registrable_domain: "example.com",
-        subdomain_labels: [],
-        registrable_labels: ["example", "com"],
-        idna_ascii_hostname: "example.com",
-        idna_unicode_hostname: "example.com",
-        is_ip_literal: false,
-        ip_literal: null,
-        obfuscated_ipv4: null,
-        obfuscated_ipv4_notes: [],
-        ipv6_mapped_ipv4: null,
-        normalization_notes: []
-      },
-      evidence_rows: [],
-      redirect_trace: null,
-      suppression_trace: null
-    }
-  }
-} as const;
+type Severity = "INFO" | "LOW" | "MEDIUM" | "HIGH" | "CRITICAL";
 
-const SUSPICIOUS_URL_RESPONSE = {
-  schema_version: "2.0",
-  flow: "analyze",
-  mode: "single",
-  input_type: "url",
-  item_count: 1,
-  item: {
-    subject: "https://login.example.test",
-    result: {
-      input: {
-        input_type: "url",
-        content: "https://login.example.test",
-        metadata: { network_enabled: true }
+interface MockFinding {
+  module: string;
+  category: string;
+  severity: Severity;
+  confidence: "LOW" | "MEDIUM" | "HIGH";
+  risk_score: number;
+  title: string;
+  explanation: string;
+  family_explanation: string;
+  evidence: Array<{ label: string; value: string }>;
+  recommendations: string[];
+}
+
+interface MockResponseOptions {
+  subject: string;
+  riskScore: number;
+  severity: Severity;
+  summary: string;
+  reasons?: string[];
+  recommendations?: string[];
+  findings?: MockFinding[];
+  detailedAnalyst?: boolean;
+}
+
+const DETAILED_FINDINGS: MockFinding[] = [
+  {
+    module: "url_structure",
+    category: "URL002_DECEPTIVE_SUBDOMAIN",
+    severity: "HIGH",
+    confidence: "HIGH",
+    risk_score: 65,
+    title: "Suspicious brand token appears in a subdomain",
+    explanation: "A known brand token appears outside the registrable domain.",
+    family_explanation: "This link places a familiar site name in the wrong part of the address.",
+    evidence: [
+      { label: "Hostname", value: "login.example.test" },
+      { label: "Registrable Domain", value: "example.test" }
+    ],
+    recommendations: ["Verify the destination through a trusted bookmark."]
+  },
+  {
+    module: "redirect",
+    category: "RED002_CROSS_DOMAIN_REDIRECT",
+    severity: "INFO",
+    confidence: "MEDIUM",
+    risk_score: 40,
+    title: "Redirect chain changes registrable domain",
+    explanation: "The redirect chain moves across different registrable domains.",
+    family_explanation: "This link starts on one site name and ends on a different site name.",
+    evidence: [
+      {
+        label: "Chain",
+        value: "https://login.example.test -> https://redirect.gateway.test -> https://final.example.org"
       },
-      findings: [
-        {
-          module: "url_structure",
-          category: "URL002_DECEPTIVE_SUBDOMAIN",
-          severity: "HIGH",
-          confidence: "HIGH",
-          risk_score: 65,
-          title: "Suspicious brand token appears in a subdomain",
-          explanation: "A known brand token appears outside the registrable domain.",
-          family_explanation: "This link places a familiar site name in the wrong part of the address.",
-          evidence: [
-            { label: "Hostname", value: "login.example.test" },
-            { label: "Registrable Domain", value: "example.test" }
-          ],
-          recommendations: ["Verify the destination through a trusted bookmark."]
-        },
-        {
-          module: "redirect",
-          category: "RED002_CROSS_DOMAIN_REDIRECT",
-          severity: "INFO",
-          confidence: "MEDIUM",
-          risk_score: 40,
-          title: "Redirect chain changes registrable domain",
-          explanation: "The redirect chain moves across different registrable domains.",
-          family_explanation: "This link starts on one site name and ends on a different site name.",
-          evidence: [
-            {
-              label: "Chain",
-              value:
-                "https://login.example.test -> https://redirect.gateway.test -> https://final.example.org"
-            },
-            { label: "Domain Path", value: "example.test -> gateway.test -> example.org" },
-            { label: "Redirect Hops", value: "2" }
-          ],
-          recommendations: ["Verify that the final site name is expected and trusted."]
-        }
-      ],
-      overall_risk: 65,
-      overall_severity: "HIGH",
-      summary: "Strong warning signs were found in this destination.",
-      analyzed_at: "2026-03-06T00:00:00Z"
-    },
-    family: {
-      risk_score: 65,
-      severity: "HIGH",
-      summary: "Strong warning signs were found in this destination.",
-      signal_confidence: "HIGH",
-      reasons: ["This link places a familiar site name in the wrong part of the address."],
-      recommendations: ["Verify the destination through a trusted bookmark."]
-    },
-    analyst: {
-      domain_anatomy: {
-        submitted_url: "https://login.example.test",
-        canonical_url: "https://login.example.test/",
-        hostname: "login.example.test",
-        canonical_hostname: "login.example.test",
-        registrable_domain: "example.test",
-        canonical_registrable_domain: "example.test",
-        subdomain_labels: ["login"],
-        registrable_labels: ["example", "test"],
-        idna_ascii_hostname: "login.example.test",
-        idna_unicode_hostname: "login.example.test",
-        is_ip_literal: false,
-        ip_literal: null,
-        obfuscated_ipv4: null,
-        obfuscated_ipv4_notes: [],
-        ipv6_mapped_ipv4: null,
-        normalization_notes: []
-      },
-      evidence_rows: [
-        {
-          module: "url_structure",
-          category: "URL002_DECEPTIVE_SUBDOMAIN",
-          finding_key: "url_structure:URL002_DECEPTIVE_SUBDOMAIN",
-          compare_key: "url_structure:URL002_DECEPTIVE_SUBDOMAIN",
-          sort_index: 0,
-          severity: "HIGH",
-          confidence: "HIGH",
-          cumulative_risk_score: 65,
-          risk_delta: null,
-          title: "Suspicious brand token appears in a subdomain",
-          explanation: "A known brand token appears outside the registrable domain.",
-          family_explanation: "This link places a familiar site name in the wrong part of the address.",
-          recommendations: ["Verify the destination through a trusted bookmark."],
-          evidence: [
-            { key: "hostname", label: "Hostname", value: "login.example.test" },
-            { key: "registrable_domain", label: "Registrable Domain", value: "example.test" }
-          ],
-          evidence_map: {
-            hostname: "login.example.test",
-            registrable_domain: "example.test"
-          }
-        },
-        {
-          module: "redirect",
-          category: "RED002_CROSS_DOMAIN_REDIRECT",
-          finding_key: "redirect:RED002_CROSS_DOMAIN_REDIRECT",
-          compare_key: "redirect:RED002_CROSS_DOMAIN_REDIRECT",
-          sort_index: 1,
-          severity: "INFO",
-          confidence: "MEDIUM",
-          cumulative_risk_score: 40,
-          risk_delta: null,
-          title: "Redirect chain changes registrable domain",
-          explanation: "The redirect chain moves across different registrable domains.",
-          family_explanation: "This link starts on one site name and ends on a different site name.",
-          recommendations: ["Verify that the final site name is expected and trusted."],
-          evidence: [
-            {
-              key: "chain",
-              label: "Chain",
-              value:
-                "https://login.example.test -> https://redirect.gateway.test -> https://final.example.org"
-            },
-            {
-              key: "domain_path",
-              label: "Domain Path",
-              value: "example.test -> gateway.test -> example.org"
-            }
-          ],
-          evidence_map: {
-            chain:
-              "https://login.example.test -> https://redirect.gateway.test -> https://final.example.org",
-            domain_path: "example.test -> gateway.test -> example.org"
-          }
-        }
-      ],
-      redirect_trace: {
-        hops: [
-          "https://login.example.test",
-          "https://redirect.gateway.test",
-          "https://final.example.org"
-        ],
-        start_url: "https://login.example.test",
-        final_url: "https://final.example.org",
-        registrable_domain_path: ["example.test", "gateway.test", "example.org"],
-        hop_count: 2,
-        crosses_registrable_domain: true,
-        max_hops_reached: false,
-        timed_out: false,
-        loop_target: null,
-        request_error: null
-      },
-      suppression_trace: {
-        hostname: "login.example.test",
-        configured_allowlist_domains: ["example.test"],
-        configured_allowlist_categories: ["URL"],
-        configured_allowlist_findings: [],
-        matched_allowlist_domains: ["example.test"],
-        suppressed_count: 1,
-        suppressed_rows: [
-          {
-            module: "url_structure",
-            category: "URL003_NESTED_URL_PARAMETER",
-            finding_key: "url_structure:URL003_NESTED_URL_PARAMETER",
-            compare_key: "url_structure:URL003_NESTED_URL_PARAMETER:category:url",
-            sort_index: 0,
-            hostname: "login.example.test",
-            matched_allowlist_domain: "example.test",
-            suppression_scope: "category",
-            matched_rule: "URL",
-            reason:
-              "Suppressed because the hostname matched an allowlist domain and category prefix URL was enabled."
-          }
-        ]
-      }
-    }
+      { label: "Domain Path", value: "example.test -> gateway.test -> example.org" },
+      { label: "Redirect Hops", value: "2" }
+    ],
+    recommendations: ["Verify that the final site name is expected and trusted."]
   }
-} as const;
+];
+
+function makeFinding(overrides: Partial<MockFinding> = {}): MockFinding {
+  const riskScore = overrides.risk_score ?? 35;
+  const severity = overrides.severity ?? "MEDIUM";
+
+  return {
+    module: "url_structure",
+    category: "URL001_WARNING_SIGNAL",
+    severity,
+    confidence: "MEDIUM",
+    risk_score: riskScore,
+    title: "Warning signal found",
+    explanation: "The submitted destination has a warning signal.",
+    family_explanation: "This destination has a warning signal that deserves review.",
+    evidence: [{ label: "Risk", value: String(riskScore) }],
+    recommendations: ["Verify this destination through a trusted source."],
+    ...overrides
+  };
+}
+
+function makeResponse({
+  subject,
+  riskScore,
+  severity,
+  summary,
+  reasons = [],
+  recommendations = [],
+  findings = [],
+  detailedAnalyst = false
+}: MockResponseOptions) {
+  return {
+    schema_version: "2.0",
+    flow: "analyze",
+    mode: "single",
+    input_type: "url",
+    item_count: 1,
+    item: {
+      subject,
+      result: {
+        input: {
+          input_type: "url",
+          content: subject,
+          metadata: {}
+        },
+        findings,
+        overall_risk: riskScore,
+        overall_severity: severity,
+        summary,
+        analyzed_at: "2026-03-06T00:00:00Z"
+      },
+      family: {
+        risk_score: riskScore,
+        severity,
+        summary,
+        signal_confidence: riskScore > 0 ? "HIGH" : null,
+        reasons,
+        recommendations
+      },
+      ...(detailedAnalyst
+        ? {
+            analyst: {
+              domain_anatomy: {
+                submitted_url: subject,
+                canonical_url: `${subject}/`,
+                hostname: "login.example.test",
+                canonical_hostname: "login.example.test",
+                registrable_domain: "example.test",
+                canonical_registrable_domain: "example.test",
+                subdomain_labels: ["login"],
+                registrable_labels: ["example", "test"],
+                idna_ascii_hostname: "login.example.test",
+                idna_unicode_hostname: "login.example.test",
+                is_ip_literal: false,
+                ip_literal: null,
+                obfuscated_ipv4: null,
+                obfuscated_ipv4_notes: [],
+                ipv6_mapped_ipv4: null,
+                normalization_notes: []
+              },
+              evidence_rows: DETAILED_FINDINGS.map((finding, index) => ({
+                module: finding.module,
+                category: finding.category,
+                finding_key: `${finding.module}:${finding.category}`,
+                compare_key: `${finding.module}:${finding.category}`,
+                sort_index: index,
+                severity: finding.severity,
+                confidence: finding.confidence,
+                cumulative_risk_score: finding.risk_score,
+                risk_delta: null,
+                title: finding.title,
+                explanation: finding.explanation,
+                family_explanation: finding.family_explanation,
+                recommendations: finding.recommendations,
+                evidence: finding.evidence.map((entry) => ({
+                  key: entry.label.toLowerCase().replaceAll(" ", "_"),
+                  label: entry.label,
+                  value: entry.value
+                })),
+                evidence_map: Object.fromEntries(
+                  finding.evidence.map((entry) => [
+                    entry.label.toLowerCase().replaceAll(" ", "_"),
+                    entry.value
+                  ])
+                )
+              })),
+              redirect_trace: {
+                hops: [
+                  "https://login.example.test",
+                  "https://redirect.gateway.test",
+                  "https://final.example.org"
+                ],
+                start_url: "https://login.example.test",
+                final_url: "https://final.example.org",
+                registrable_domain_path: ["example.test", "gateway.test", "example.org"],
+                hop_count: 2,
+                crosses_registrable_domain: true,
+                max_hops_reached: false,
+                timed_out: false,
+                loop_target: null,
+                request_error: null
+              },
+              suppression_trace: {
+                hostname: "login.example.test",
+                configured_allowlist_domains: ["example.test"],
+                configured_allowlist_categories: ["URL"],
+                configured_allowlist_findings: [],
+                matched_allowlist_domains: ["example.test"],
+                suppressed_count: 1,
+                suppressed_rows: [
+                  {
+                    module: "url_structure",
+                    category: "URL003_NESTED_URL_PARAMETER",
+                    finding_key: "url_structure:URL003_NESTED_URL_PARAMETER",
+                    compare_key: "url_structure:URL003_NESTED_URL_PARAMETER:category:url",
+                    sort_index: 0,
+                    hostname: "login.example.test",
+                    matched_allowlist_domain: "example.test",
+                    suppression_scope: "category",
+                    matched_rule: "URL",
+                    reason:
+                      "Suppressed because the hostname matched an allowlist domain and category prefix URL was enabled."
+                  }
+                ]
+              }
+            }
+          }
+        : {})
+    }
+  };
+}
+
+const SAFE_URL_RESPONSE = makeResponse({
+  subject: "https://example.com",
+  riskScore: 0,
+  severity: "INFO",
+  summary:
+    "No obvious lookalike-link warning signs found. For important accounts, type the website address yourself."
+});
+
+const CAUTION_URL_RESPONSE = makeResponse({
+  subject: "https://notice.example.com",
+  riskScore: 35,
+  severity: "MEDIUM",
+  summary: "Some warning signs were found in this destination.",
+  findings: [makeFinding()],
+  reasons: ["This destination has a warning signal that deserves review."],
+  recommendations: ["Verify this destination through a trusted source."]
+});
+
+const SUSPICIOUS_URL_RESPONSE = makeResponse({
+  subject: "https://login.example.test",
+  riskScore: 65,
+  severity: "HIGH",
+  summary: "Strong warning signs were found in this destination.",
+  findings: DETAILED_FINDINGS,
+  reasons: ["This link places a familiar site name in the wrong part of the address."],
+  recommendations: ["Verify the destination through a trusted bookmark."],
+  detailedAnalyst: true
+});
+
+const DANGEROUS_URL_RESPONSE = makeResponse({
+  subject: "https://credential-theft.example.test",
+  riskScore: 92,
+  severity: "CRITICAL",
+  summary: "Critical warning signs were found in this destination.",
+  findings: [
+    makeFinding({
+      category: "URL999_CRITICAL_RISK",
+      severity: "CRITICAL",
+      confidence: "HIGH",
+      risk_score: 92,
+      family_explanation: "This destination has critical warning signals."
+    })
+  ],
+  reasons: ["This destination has critical warning signals."],
+  recommendations: ["Do not open the link or reply to the request."]
+});
 
 async function gotoAnalyze(page: Page) {
   await page.addInitScript(() => {
@@ -250,12 +270,53 @@ async function gotoAnalyze(page: Page) {
   ).toBeVisible();
 }
 
-async function mockAnalyzeResponse(page: Page, response: object) {
+async function mockAnalyzeResponse(page: Page, response: object, delayMs = 0) {
   await page.route("**/api/v2/analyze", async (route) => {
+    if (delayMs > 0) {
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
     await route.fulfill({
       status: 200,
       contentType: "application/json",
       body: JSON.stringify(response)
+    });
+  });
+}
+
+async function mockAnalyzeFailure(page: Page) {
+  await page.route("**/api/v2/analyze", async (route) => {
+    await route.fulfill({
+      status: 503,
+      contentType: "application/json",
+      body: JSON.stringify({
+        detail: {
+          schema_version: "1.0",
+          error: {
+            code: "API_UNAVAILABLE",
+            message: "The analysis service is temporarily unavailable.",
+            status: 503
+          }
+        }
+      })
+    });
+  });
+}
+
+async function mockQrFailure(page: Page, code: string) {
+  await page.route("**/api/v1/qr/scan", async (route) => {
+    await route.fulfill({
+      status: 422,
+      contentType: "application/json",
+      body: JSON.stringify({
+        detail: {
+          schema_version: "1.0",
+          error: {
+            code,
+            message: "QR scan could not return a URL.",
+            status: 422
+          }
+        }
+      })
     });
   });
 }
@@ -265,7 +326,15 @@ async function submitUrl(page: Page, url: string) {
   await page.getByRole("button", { name: "Analyze" }).click();
 }
 
-test("URL analysis renders the simplified verdict hierarchy with collapsed evidence", async ({
+async function uploadQrImage(page: Page) {
+  await page.getByLabel("QR image (optional)").setInputFiles({
+    name: "qr.png",
+    mimeType: "image/png",
+    buffer: Buffer.from([0x89, 0x50, 0x4e, 0x47])
+  });
+}
+
+test("URL analysis renders the simplified verdict hierarchy with keyboard-accessible evidence", async ({
   page
 }) => {
   await mockAnalyzeResponse(page, SUSPICIOUS_URL_RESPONSE);
@@ -290,11 +359,14 @@ test("URL analysis renders the simplified verdict hierarchy with collapsed evide
   await expect(nextActions.getByRole("listitem")).toHaveCount(3);
 
   const technicalDetails = page.getByTestId("analyze-technical-details");
+  const technicalSummary = technicalDetails.locator("summary").first();
   await expect(technicalDetails).toBeVisible();
   await expect(technicalDetails).toHaveJSProperty("open", false);
   await expect(technicalDetails.locator("h3", { hasText: "Domain anatomy" })).toBeHidden();
 
-  await technicalDetails.locator("summary").first().click();
+  await technicalSummary.focus();
+  await expect(technicalSummary).toBeFocused();
+  await page.keyboard.press("Enter");
   await expect(technicalDetails).toHaveJSProperty("open", true);
   await expect(technicalDetails.locator("h3", { hasText: "Domain anatomy" })).toBeVisible();
   await expect(technicalDetails.locator("h3", { hasText: "Redirect path" })).toBeVisible();
@@ -302,21 +374,166 @@ test("URL analysis renders the simplified verdict hierarchy with collapsed evide
   await expect(technicalDetails.locator("h3", { hasText: "Evidence panel" })).toBeVisible();
 });
 
-test("safe action display maps to Safe and Low without showing email tabs", async ({ page }) => {
-  await mockAnalyzeResponse(page, SAFE_URL_RESPONSE);
+test("initial, validation, and focus states stay accessible", async ({ page }) => {
   await gotoAnalyze(page);
 
-  await expect(page.getByRole("tab", { name: "Email" })).toHaveCount(0);
-  await expect(page.getByLabel("Email headers")).toHaveCount(0);
-  await expect(page.getByRole("button", { name: /Analyze email/i })).toHaveCount(0);
+  await expect(page.getByLabel("URL")).toHaveValue("");
+  await expect(page.getByRole("heading", { name: "Paste a link or upload a QR image" })).toBeVisible();
+  await expect(page.getByTestId("analyze-verdict-card")).toHaveCount(0);
 
+  await page.keyboard.press("Tab");
+  await expect(page.getByRole("link", { name: "Analyze" })).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(page.getByLabel("URL")).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(page.getByLabel("QR image (optional)")).toBeFocused();
+  await page.keyboard.press("Tab");
+  await expect(page.getByRole("button", { name: "Analyze" })).toBeFocused();
+
+  await page.getByRole("button", { name: "Analyze" }).click();
+  const validationMessage = page.getByTestId("analyze-validation-message");
+  await expect(validationMessage).toHaveText("Paste a URL or upload a QR image to analyze.");
+  await expect(validationMessage).toHaveAttribute("role", "alert");
+  await expect(page.getByLabel("URL")).toHaveAttribute("aria-invalid", "true");
+});
+
+test("loading state disables inputs and announces progress", async ({ page }) => {
+  await mockAnalyzeResponse(page, SAFE_URL_RESPONSE, 500);
+  await gotoAnalyze(page);
   await submitUrl(page, "https://example.com");
 
-  const verdictCard = page.getByTestId("analyze-verdict-card");
-  await expect(verdictCard.getByText("Safe", { exact: true })).toBeVisible();
-  const riskPill = page.getByTestId("analyze-risk-pill");
-  await expect(riskPill).toHaveText("Low");
-  await expect(riskPill).toHaveAccessibleName("Risk level Low");
+  await expect(page.getByRole("heading", { name: "Analyzing this submission" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Analyzing..." })).toBeDisabled();
+  await expect(page.getByLabel("URL")).toBeDisabled();
+  await expect(page.getByLabel("QR image (optional)")).toBeDisabled();
+  await expect(page.getByTestId("analyze-result-area")).toHaveAttribute("aria-busy", "true");
+
+  await expect(page.getByTestId("analyze-verdict-card")).toBeVisible();
+});
+
+test("URL API failure is plain-English and does not replace a prior success", async ({ page }) => {
+  await mockAnalyzeResponse(page, SAFE_URL_RESPONSE);
+  await gotoAnalyze(page);
+  await submitUrl(page, "https://example.com");
+  await expect(page.getByTestId("analyze-verdict-card").getByText("Safe", { exact: true })).toBeVisible();
+
+  await page.unroute("**/api/v2/analyze");
+  await mockAnalyzeFailure(page);
+  await submitUrl(page, "https://offline.example.test");
+
+  await expect(page.getByRole("heading", { name: "Request failed" })).toBeVisible();
+  await expect(page.getByText("The analysis service is temporarily unavailable.")).toBeVisible();
+  await expect(page.getByText("The previous successful result is still shown below.")).toBeVisible();
+  await expect(page.getByTestId("analyze-verdict-card").getByText("Safe", { exact: true })).toBeVisible();
+});
+
+test("validation does not clear previous results for mixed or invalid QR inputs", async ({ page }) => {
+  await mockAnalyzeResponse(page, SAFE_URL_RESPONSE);
+  await gotoAnalyze(page);
+  await submitUrl(page, "https://example.com");
+  await expect(page.getByTestId("analyze-verdict-card")).toBeVisible();
+
+  await uploadQrImage(page);
+  await page.getByRole("button", { name: "Analyze" }).click();
+  await expect(page.getByTestId("analyze-validation-message")).toHaveText(
+    "Choose either a URL or a QR image, not both."
+  );
+  await expect(page.getByTestId("analyze-verdict-card")).toBeVisible();
+
+  await page.getByLabel("URL").fill("");
+  await page.getByLabel("QR image (optional)").setInputFiles({
+    name: "not-a-qr.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("not a qr image")
+  });
+  await page.getByRole("button", { name: "Analyze" }).click();
+  await expect(page.getByTestId("analyze-validation-message")).toHaveText(
+    "Upload an image file for QR scanning."
+  );
+  await expect(page.getByTestId("analyze-verdict-card")).toBeVisible();
+});
+
+for (const code of [
+  "QRC_DECODER_UNAVAILABLE",
+  "QRC_MULTIPART_UNAVAILABLE",
+  "QRC_NO_URL_PAYLOADS"
+]) {
+  test(`QR error ${code} is readable and actionable`, async ({ page }) => {
+    await mockQrFailure(page, code);
+    await gotoAnalyze(page);
+    await uploadQrImage(page);
+    await page.getByRole("button", { name: "Analyze" }).click();
+
+    await expect(page.getByRole("heading", { name: "Request failed" })).toBeVisible();
+    await expect(page.getByText(code)).toBeVisible();
+    await expect(page.getByText(/paste the URL|Upload a QR code/i)).toBeVisible();
+  });
+}
+
+test.describe("display mapping", () => {
+  const variants = [
+    {
+      name: "safe / Low",
+      response: SAFE_URL_RESPONSE,
+      url: "https://example.com",
+      verdict: "Safe",
+      risk: "Low"
+    },
+    {
+      name: "caution / Medium",
+      response: CAUTION_URL_RESPONSE,
+      url: "https://notice.example.com",
+      verdict: "Caution",
+      risk: "Medium"
+    },
+    {
+      name: "avoid / Suspicious / High",
+      response: SUSPICIOUS_URL_RESPONSE,
+      url: "https://login.example.test",
+      verdict: "Suspicious",
+      risk: "High"
+    },
+    {
+      name: "block / Dangerous / Critical",
+      response: DANGEROUS_URL_RESPONSE,
+      url: "https://credential-theft.example.test",
+      verdict: "Dangerous",
+      risk: "Critical"
+    }
+  ];
+
+  for (const variant of variants) {
+    test(`${variant.name} result renders expected labels`, async ({ page }) => {
+      await mockAnalyzeResponse(page, variant.response);
+      await gotoAnalyze(page);
+      await submitUrl(page, variant.url);
+
+      const verdictCard = page.getByTestId("analyze-verdict-card");
+      await expect(verdictCard.getByText(variant.verdict, { exact: true })).toBeVisible();
+      const riskPill = page.getByTestId("analyze-risk-pill");
+      await expect(riskPill).toHaveText(variant.risk);
+      await expect(riskPill).toHaveAccessibleName(`Risk level ${variant.risk}`);
+    });
+  }
+});
+
+test("mobile viewport keeps the input and result cards usable", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 844 });
+  await mockAnalyzeResponse(page, SUSPICIOUS_URL_RESPONSE);
+  await gotoAnalyze(page);
+
+  await expect(page.getByTestId("analyze-input-card")).toBeVisible();
+  await expect(page.getByLabel("URL")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Analyze" })).toBeVisible();
+
+  await submitUrl(page, "https://login.example.test");
+  await expect(page.getByTestId("analyze-verdict-card")).toBeVisible();
   await expect(page.getByTestId("analyze-key-reasons")).toBeVisible();
   await expect(page.getByTestId("analyze-next-actions")).toBeVisible();
+
+  const reasonsBox = await page.getByTestId("analyze-key-reasons").boundingBox();
+  const actionsBox = await page.getByTestId("analyze-next-actions").boundingBox();
+  expect(reasonsBox).not.toBeNull();
+  expect(actionsBox).not.toBeNull();
+  expect(actionsBox!.y).toBeGreaterThan(reasonsBox!.y);
 });

--- a/ui/package.json
+++ b/ui/package.json
@@ -10,7 +10,7 @@
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "smoke:api": "node scripts/api-contract-smoke.mjs",
-    "smoke:e2e": "playwright test e2e/analyze.smoke.spec.ts"
+    "smoke:e2e": "playwright test e2e/analyze.smoke.spec.ts e2e/analyze.verdict.spec.ts"
   },
   "dependencies": {
     "next": "^15.0.0",


### PR DESCRIPTION
## Summary

- Hardens loading, validation, URL/API error, and QR decoder-unavailable states.
- Preserves previous successful results through validation/API failures.
- Improves accessible labels/descriptions, live regions, disabled input behavior, focus styling, and keyboard coverage for technical details.
- Adds mocked coverage for Safe/Low, Caution/Medium, Suspicious/High, and Dangerous/Critical verdict variants.
- Adds mobile viewport smoke coverage.
- Adds analyze.verdict.spec.ts to npm run smoke:e2e so CI's existing browser smoke command enforces the simplified result-card coverage.

Closes #21.

## Validation

- npm run lint
- npm run typecheck
- npm run build
- npm run smoke:api
- npm run smoke:e2e
- npx playwright test e2e/analyze.verdict.spec.ts
- git diff --check
- In-app browser check on /analyze at desktop/mobile widths

Note: observed unrelated missing /favicon.ico 404 in browser console.